### PR TITLE
`MemberStateEvent` and refactoring

### DIFF
--- a/src/matrix/Sync.ts
+++ b/src/matrix/Sync.ts
@@ -33,7 +33,7 @@ import type {EventKey} from "./room/timeline/EventKey";
 import type {MemberChange, MemberData} from "./room/members/RoomMember";
 import type {PendingEvent} from "./room/sending/PendingEvent";
 import type {HeroChanges} from "./room/members/Heroes";
-import type {HistoryVisibility, PowerLevelsEvent} from "./net/types/roomEvents";
+import type {HistoryVisibility, PowerLevelsStateEvent} from "./net/types/roomEvents";
 import type {ArchivedRoom} from "./room/ArchivedRoom";
 import type {Invite} from "./room/Invite";
 import type {Transaction} from "./storage/idb/Transaction";
@@ -556,7 +556,7 @@ type RoomWriteSyncChanges = {
     memberChanges: Map<string, MemberChange | undefined>;
     removedPendingEvents?: PendingEvent[];
     heroChanges?: HeroChanges;
-    powerLevelsEvent?: PowerLevelsEvent;
+    powerLevelsEvent?: PowerLevelsStateEvent;
     encryptionChanges?: RoomEncryptionWriteSyncChanges;
 }
 

--- a/src/matrix/net/types/roomEvents.ts
+++ b/src/matrix/net/types/roomEvents.ts
@@ -45,7 +45,7 @@ export enum RoomEventType {
 /**
  * https://spec.matrix.org/v1.4/client-server-api/#mroompower_levels
  */
-export type PowerLevelsEvent = StateEvent<RoomEventType.PowerLevels, PowerLevelsContent, "">
+export type PowerLevelsStateEvent = StateEvent<RoomEventType.PowerLevels, PowerLevelsContent, "">
 
 type PowerLevelsContent = {
   ban: number;
@@ -61,3 +61,39 @@ type PowerLevelsContent = {
 }
 
 export type HistoryVisibility = "invited" | "joined" | "shared" | "world readable"
+
+/**
+ * https://spec.matrix.org/v1.4/client-server-api/#mroommember
+ *
+ * Special note about the state key from the docs:
+ * The user_id this membership event relates to. In all cases except for when membership is join,
+ * the user ID sending the event does not need to match the user ID in the state_key, unlike other events.
+ * Regular authorisation rules still apply.
+ */
+export type MemberStateEvent = StateEvent<RoomEventType.Member, MemberContent, string>
+
+type MemberContent = {
+  avatar_url?: string;
+  displayname?: string;
+  is_direct?: boolean;
+  join_authorised_via_users_server?: string;
+  membership?: Membership;
+  reason?: string;
+  third_party_invite: {
+    display_name: string;
+    signed: {
+      mxid: string;
+      signatures: Signatures;
+      token: string;
+    };
+  };
+}
+
+export type Membership = "invite" | "join" | "knock" | "leave" | "ban"
+
+// A map from user ID, to a map from <algorithm>:<device_id> to the signature.
+type Signatures = {
+  [key: string]: {
+    [key: string]: string;
+  }
+}

--- a/src/matrix/net/types/sync.ts
+++ b/src/matrix/net/types/sync.ts
@@ -87,7 +87,7 @@ type State = {
   events: ClientEventWithoutRoomID[];
 };
 
-type ClientEventWithoutRoomID = {
+export type ClientEventWithoutRoomID = {
   content: Object;
   event_id: string;
   origin_server_ts: number;

--- a/src/matrix/room/ArchivedRoom.js
+++ b/src/matrix/room/ArchivedRoom.js
@@ -16,7 +16,8 @@ limitations under the License.
 
 import {reduceStateEvents} from "./RoomSummary";
 import {BaseRoom} from "./BaseRoom";
-import {RoomMember, EVENT_TYPE as MEMBER_EVENT_TYPE} from "./members/RoomMember";
+import {RoomMember} from "./members/RoomMember";
+import {RoomEventType} from "../net/types/roomEvents";
 
 export class ArchivedRoom extends BaseRoom {
     constructor(options) {
@@ -174,7 +175,7 @@ export class ArchivedRoom extends BaseRoom {
 
 function findKickDetails(roomResponse, ownUserId) {
     const kickEvent = reduceStateEvents(roomResponse, (kickEvent, event) => {
-        if (event.type === MEMBER_EVENT_TYPE) {
+        if (event.type === RoomEventType.Member) {
             // did we get kicked?
             if (event.state_key === ownUserId && event.sender !== event.state_key) {
                 kickEvent = event;

--- a/src/matrix/room/Invite.js
+++ b/src/matrix/room/Invite.js
@@ -17,7 +17,8 @@ limitations under the License.
 import {EventEmitter} from "../../utils/EventEmitter";
 import {SummaryData, processStateEvent} from "./RoomSummary";
 import {Heroes} from "./members/Heroes";
-import {MemberChange, RoomMember, EVENT_TYPE as MEMBER_EVENT_TYPE} from "./members/RoomMember";
+import {MemberChange, RoomMember} from "./members/RoomMember";
+import {RoomEventType} from "../net/types/roomEvents";
 
 export class Invite extends EventEmitter {
     constructor({roomId, user, hsApi, mediaRepository, emitCollectionRemove, emitCollectionUpdate, platform}) {
@@ -211,7 +212,7 @@ export class Invite extends EventEmitter {
     }
 
     async _createHeroes(inviteState, log) {
-        const members = inviteState.filter(e => e.type === MEMBER_EVENT_TYPE);
+        const members = inviteState.filter(e => e.type === RoomEventType.Member);
         const otherMembers = members.filter(e => e.state_key !== this._user.id);
         const memberChanges = otherMembers.reduce((map, e) => {
             const member = RoomMember.fromMemberEvent(this.id, e);
@@ -231,11 +232,11 @@ export class Invite extends EventEmitter {
     }
 
     _getMyInvite(inviteState) {
-        return inviteState.find(e => e.type === MEMBER_EVENT_TYPE && e.state_key === this._user.id);
+        return inviteState.find(e => e.type === RoomEventType.Member && e.state_key === this._user.id);
     }
 
     _getInviter(myInvite, inviteState) {
-        const inviterMemberEvent = inviteState.find(e => e.type === MEMBER_EVENT_TYPE && e.state_key === myInvite.sender);
+        const inviterMemberEvent = inviteState.find(e => e.type === RoomEventType.Member && e.state_key === myInvite.sender);
         if (inviterMemberEvent) {
             return RoomMember.fromMemberEvent(this.id, inviterMemberEvent);
         }

--- a/src/matrix/room/members/RoomMember.ts
+++ b/src/matrix/room/members/RoomMember.ts
@@ -16,10 +16,8 @@ limitations under the License.
 
 import { StateEvent } from "../../storage/types";
 import {getPrevContentFromStateEvent} from "../common";
+import {MemberStateEvent, Membership} from "../../net/types/roomEvents";
 
-export const EVENT_TYPE = "m.room.member";
-
-type Membership = "join" | "leave" | "invite" | "ban";
 export interface MemberData {
     roomId: string;
     userId: string;
@@ -39,7 +37,7 @@ export class RoomMember {
         return new RoomMember({roomId, userId, membership});
     }
 
-    static fromMemberEvent(roomId: string, memberEvent: StateEvent): RoomMember | undefined {
+    static fromMemberEvent(roomId: string, memberEvent: MemberStateEvent): RoomMember | undefined {
         const userId = memberEvent?.state_key;
         if (typeof userId !== "string") {
             return;
@@ -73,7 +71,7 @@ export class RoomMember {
     static _validateAndCreateMember(
         roomId: string,
         userId: string,
-        membership: Membership,
+        membership: Membership | undefined,
         displayName: string,
         avatarUrl: string
     ): RoomMember | undefined {

--- a/src/matrix/room/members/load.ts
+++ b/src/matrix/room/members/load.ts
@@ -20,8 +20,8 @@ import type {ILogger, ILogItem} from "../../../logging/types";
 import type {Transaction} from "../../storage/idb/Transaction";
 import type {RoomSummary} from "../RoomSummary";
 import type {HomeServerApi} from "../../net/HomeServerApi";
-import type {StateEvent} from "../../storage/types";
 import type {SummaryData} from "../RoomSummary";
+import {MemberStateEvent} from "../../net/types/roomEvents";
 
 
 async function loadMembers({roomId, storage, txn}: LoadMembersOptions): Promise<RoomMember[]> {
@@ -63,7 +63,7 @@ async function fetchMembers(
     try {
         summaryChanges = summary.writeHasFetchedMembers(true, txn);
         const {roomMembers} = txn;
-        const memberEvents: StateEvent[] = memberResponse.chunk;
+        const memberEvents: MemberStateEvent[] = memberResponse.chunk;
         if (!Array.isArray(memberEvents)) {
             throw new Error("malformed");
         }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -24,7 +24,7 @@ import {RoomMember} from "../members/RoomMember";
 import {getRelation, ANNOTATION_RELATION_TYPE} from "./relations";
 import {REDACTION_TYPE} from "../common";
 import {NonPersistedEventEntry} from "./entries/NonPersistedEventEntry";
-import {EVENT_TYPE as MEMBER_EVENT_TYPE} from "../members/RoomMember";
+import {RoomEventType} from "../../net/types/roomEvents";
 
 export class Timeline {
     constructor({roomId, storage, closeCallback, fragmentIdComparer, pendingEvents, clock, powerLevelsObservable, hsApi}) {
@@ -373,7 +373,7 @@ export class Timeline {
     async _getEventFromHomeserver(eventId) {
         const response = await this._hsApi.context(this._roomId, eventId, 0).response();
         const sender = response.event.sender;
-        const member = response.state.find(e => e.type === MEMBER_EVENT_TYPE && e.user_id === sender);
+        const member = response.state.find(e => e.type === RoomEventType.Member && e.user_id === sender);
         const entry = {
             event: response.event,
             displayName: member.content.displayname,
@@ -501,7 +501,7 @@ export function tests() {
             const result = {
                 event: withTextBody("foo", createEvent("m.room.message", "event_id_1", alice)),
                 state: [{
-                    type: MEMBER_EVENT_TYPE,
+                    type: RoomEventType.Member,
                     user_id: alice,
                     content: {
                         displayName: "",

--- a/src/matrix/room/timeline/persistence/GapWriter.ts
+++ b/src/matrix/room/timeline/persistence/GapWriter.ts
@@ -17,7 +17,9 @@ limitations under the License.
 import {EventKey} from "../EventKey";
 import {EventEntry} from "../entries/EventEntry";
 import {createEventEntry, directionalAppend} from "./common";
-import {RoomMember, EVENT_TYPE as MEMBER_EVENT_TYPE} from "../../members/RoomMember";
+import {RoomMember} from "../../members/RoomMember";
+import {RoomEventType} from "../../../net/types/roomEvents";
+import {MemberStateEvent} from "../../../net/types/roomEvents";
 import type {Storage} from "../../../storage/idb/Storage";
 
 type Options = {
@@ -133,14 +135,14 @@ export class GapWriter {
         direction: Direction
     ): RoomMember | undefined {
         function isOurUser(event: StateEvent): boolean {
-            return event.type === MEMBER_EVENT_TYPE && event.state_key === userId;
+            return event.type === RoomEventType.Member && event.state_key === userId;
         }
         // older messages are at a higher index in the array when going backwards
         const inc = direction.isBackward ? 1 : -1;
         for (let i = index + inc; i >= 0 && i < events.length; i += inc) {
             const event = events[i];
             if (isOurUser(event)) {
-                return RoomMember.fromMemberEvent(this._roomId, event);
+                return RoomMember.fromMemberEvent(this._roomId, event as MemberStateEvent);
             }
         }
         // look into newer events, but using prev_content if found.
@@ -157,7 +159,7 @@ export class GapWriter {
         // Don't assume state is set though, as it can be empty at the top of the timeline in some circumstances
         const stateMemberEvent = state?.find(isOurUser);
         if (stateMemberEvent) {
-            return RoomMember.fromMemberEvent(this._roomId, stateMemberEvent);
+            return RoomMember.fromMemberEvent(this._roomId, stateMemberEvent as MemberStateEvent);
         }
     }
 

--- a/src/matrix/storage/idb/schema.ts
+++ b/src/matrix/storage/idb/schema.ts
@@ -1,7 +1,7 @@
 import {IDOMStorage} from "./types";
 import {ITransaction} from "./QueryTarget";
 import {iterateCursor, NOT_DONE, reqAsPromise} from "./utils";
-import {RoomMember, EVENT_TYPE as MEMBER_EVENT_TYPE} from "../../room/members/RoomMember";
+import {RoomMember} from "../../room/members/RoomMember";
 import {SESSION_E2EE_KEY_PREFIX} from "../../e2ee/common";
 import {RoomMemberStore} from "./stores/RoomMemberStore";
 import {InboundGroupSessionEntry, BackupStatus, KeySource} from "./stores/InboundGroupSessionStore";
@@ -10,6 +10,7 @@ import {SessionStore} from "./stores/SessionStore";
 import {Store} from "./Store";
 import {encodeScopeTypeKey} from "./stores/OperationStore";
 import {ILogItem} from "../../../logging/types";
+import {MemberStateEvent, RoomEventType} from "../../net/types/roomEvents";
 
 
 export type MigrationFunc = (db: IDBDatabase, txn?: IDBTransaction, localStorage?: IDOMStorage, log?: ILogItem) => Promise<void> | void;
@@ -78,9 +79,9 @@ async function createMemberStore(db: IDBDatabase, txn: IDBTransaction): Promise<
     // migrate existing member state events over
     const roomState = txn.objectStore("roomState");
     await iterateCursor<RoomStateEntry>(roomState.openCursor(), entry => {
-        if (entry.event.type === MEMBER_EVENT_TYPE) {
+        if (entry.event.type === RoomEventType.Member) {
             roomState.delete(entry.key);
-            const member = RoomMember.fromMemberEvent(entry.roomId, entry.event);
+            const member = RoomMember.fromMemberEvent(entry.roomId, entry.event as MemberStateEvent);
             if (member) {
                 roomMembers.set(member.serialize());
             }


### PR DESCRIPTION
* Adds a MemberStateEvent to represent m.room.member events.
* Refactors the typing logic from SyncWriter.writeSync on down to better reflect what we know about the objects being passed to us via the server API.

Create a corresponding PR in `vector-im` once https://github.com/vector-im/hydrogen-web/pull/902 is merged.