### PR TITLE
Separate spaces from rooms on sync

### DIFF
--- a/src/domain/session/leftpanel/LeftPanelViewModel.ts
+++ b/src/domain/session/leftpanel/LeftPanelViewModel.ts
@@ -31,7 +31,7 @@ import { Session } from "../../../matrix/Session";
 import { SegmentType } from "../../navigation";
 import type { Path } from "../../navigation/Navigation";
 
-type LOptions = { session: Session } & ViewModelOptions;
+type Options = { session: Session } & ViewModelOptions;
 
 export class LeftPanelViewModel extends ViewModel<
     SegmentType,
@@ -51,7 +51,7 @@ export class LeftPanelViewModel extends ViewModel<
         this.urlRouter.urlForSegment("create-room");
     gridEnabled: boolean;
 
-    constructor(options: LOptions) {
+    constructor(options: Options) {
         super(options);
         const { session } = options;
         this._tileViewModelsMap = this._mapTileViewModels(

--- a/src/matrix/Session.ts
+++ b/src/matrix/Session.ts
@@ -110,8 +110,8 @@ export class Session {
     private _megolmEncryption: MegOlmEncryption;
     private _megolmDecryption?: MegOlmDecryption;
     private _getSyncToken: () => string | undefined;
-    private _keyBackup: ObservableValue<KeyBackup | undefined | null>;
-    private _observedRoomStatus: Map<string, RetainedObservableValue<number | RoomStatus>>;
+    private _keyBackup: ObservableValue<KeyBackup | undefined>;
+    private _observedRoomStatus: Map<string, RetainedObservableValue<RoomStatus>>;
 
 
     constructor({storage, hsApi, sessionInfo, olm, olmWorker, platform, mediaRepository}: Options) {
@@ -284,7 +284,7 @@ export class Session {
             }
             if (this._keyBackup.get()) {
                 this._keyBackup.get()?.dispose();
-                this._keyBackup.set(null);
+                this._keyBackup.set(undefined);
             }
             const key = await ssssKeyFromCredential(type, credential, this._storage, this._platform, this._olm);
             // and create key backup, which needs to read from accountData
@@ -358,7 +358,7 @@ export class Session {
                 }
             }
             this._keyBackup.get()?.dispose();
-            this._keyBackup.set(null);
+            this._keyBackup.set(undefined);
         }
     }
 
@@ -609,7 +609,7 @@ export class Session {
             if (!this._keyBackup.get()) {
                 // null means key backup isn't configured yet
                 // as opposed to undefined, which means we're still checking
-                this._keyBackup.set(null);
+                this._keyBackup.set(undefined);
             }
         }
         // restore unfinished operations, like sending out room keys
@@ -918,6 +918,11 @@ export class Session {
             for (const rs of roomStates) {
                 if (rs.shouldAdd) {
                     this._observedRoomStatus.get(rs.id)?.set(RoomStatus.Joined);
+                }
+            }
+            for (const ss of spaceStates) {
+                if (ss.shouldAdd) {
+                    this._observedRoomStatus.get(ss.id)?.set(RoomStatus.Joined);
                 }
             }
             for (const is of inviteStates) {

--- a/src/matrix/Session.ts
+++ b/src/matrix/Session.ts
@@ -155,6 +155,22 @@ export class Session {
         this._createRoomEncryption = this._createRoomEncryption.bind(this);
         this._forgetArchivedRoom = this._forgetArchivedRoom.bind(this);
         this.needsKeyBackup = new ObservableValue(false);
+
+        // todo(isaiah): remove this
+        this._spaces.subscribe({
+            onReset(): void {
+                console.log("space onReset called")
+            },
+            onAdd(key: string, value: Space): void {
+                console.log(`added Space: ${key}`)
+            },
+            onUpdate(key: string, value: Space, params: any): void {
+                console.log(`updated Space: ${key}`)
+            },
+            onRemove(key: string, value: Space): void {
+                console.log(`removed Space: ${key}`)
+            },
+        })
     }
 
     get fingerprintKey(): string | undefined {
@@ -880,7 +896,7 @@ export class Session {
                 this._spaces?.add(ss.id, ss.object);
                 this._tryReplaceRoomBeingCreated(ss.id, log);
             } else if (ss.shouldRemove) {
-                this._rooms?.remove(ss.id);
+                this._spaces?.remove(ss.id);
             }
         }
         for (const is of inviteStates) {
@@ -1064,6 +1080,11 @@ export class Session {
         return archivedRoom;
     }
 
+    /**
+     * If an archived room has already been loaded into memory, retains it and returns it.
+     * Otherwise, checks the database for an archived room summary. If that exists, loads
+     * the archived room into memory.
+     */
     loadArchivedRoom(roomId: string, log?: ILogItem): ArchivedRoom | undefined {
         return this._platform.logger.wrapOrRun(log, "loadArchivedRoom", async log => {
             log.set("id", roomId);

--- a/src/matrix/Session.ts
+++ b/src/matrix/Session.ts
@@ -884,7 +884,7 @@ export class Session {
         // update the collections after sync
         for (const rs of roomStates) {
             if (rs.shouldAdd) {
-                this._rooms?.add(rs.id, rs.object);
+                this._rooms?.add(rs.id, rs.roomOrSpace);
                 this._tryReplaceRoomBeingCreated(rs.id, log);
             } else if (rs.shouldRemove) {
                 this._rooms?.remove(rs.id);
@@ -893,7 +893,7 @@ export class Session {
         // update the collections after sync
         for (const ss of spaceStates) {
             if (ss.shouldAdd) {
-                this._spaces?.add(ss.id, ss.object);
+                this._spaces?.add(ss.id, ss.roomOrSpace);
                 this._tryReplaceRoomBeingCreated(ss.id, log);
             } else if (ss.shouldRemove) {
                 this._spaces?.remove(ss.id);

--- a/src/matrix/Sync.ts
+++ b/src/matrix/Sync.ts
@@ -710,7 +710,7 @@ export class SpaceSyncProcessState extends RoomSyncProcessState {}
 
 export class ArchivedRoomSyncProcessState {
     archivedRoom: ArchivedRoom;
-    roomState: RoomSyncProcessState | undefined;
+    roomState?: RoomSyncProcessState;
     roomResponse: JoinedRoom | LeftRoom;
     membership: "join" | "leave";
     isInitialSync?: boolean;

--- a/src/matrix/Sync.ts
+++ b/src/matrix/Sync.ts
@@ -213,7 +213,7 @@ export class Sync {
         // we don't want to delay the next sync too much
         // Also, since all promises won't reject (as they have a try/catch)
         // it's fine to use Promise.all
-        await Promise.all(roomsPromises.concat(sessionPromise).concat(spacesPromises));
+        await Promise.all([sessionPromise, ...roomsPromises, ...spacesPromises]);
     }
 
     async _syncRequest(

--- a/src/matrix/Sync.ts
+++ b/src/matrix/Sync.ts
@@ -389,7 +389,6 @@ export class Sync {
             log.wrap("archivedRoom", log => ars.afterSync(log), log.level.Detail);
         }
         for(let rs of roomStates) {
-            if (!rs.changes) throw new Error("missing changes")
             log.wrap("room", log => rs.afterSync(log), log.level.Detail);
         }
         for(let ss of spaceStates) {
@@ -512,10 +511,12 @@ export class Sync {
      * whether it has the characteristic "m.space" type.
      */
     _isSpaceResponse(roomId: string, roomResponse: JoinedRoom | LeftRoom): boolean {
+        // A response with this roomId was previously identified as a space
         if (this._session.spaces?.get(roomId) !== undefined) {
             return true
         }
 
+        // We found a space creation event in this response
         if (roomResponse.timeline?.events?.filter(e => isSpaceCreateEvent(e)).length ?? 0 > 0) {
             return true
         }

--- a/src/matrix/room/BaseRoom.ts
+++ b/src/matrix/room/BaseRoom.ts
@@ -384,7 +384,7 @@ export class BaseRoom extends EventEmitter<{change: void}> {
                 this._fragmentIdComparer.add(fragment);
             }
             if (extraGapFillChanges) {
-                this._applyGapFill();
+                this._applyGapFill(extraGapFillChanges);
             }
             if (this._timeline) {
                 // these should not be added if not already there

--- a/src/matrix/room/Room.ts
+++ b/src/matrix/room/Room.ts
@@ -329,7 +329,6 @@ export class Room extends BaseRoom {
     }
 
     /**
-     * Only called if the result of writeSync had `needsAfterSyncCompleted` set.
      * Can be used to do longer running operations that resulted from the last sync,
      * like network operations.
      */

--- a/src/matrix/room/RoomSummary.ts
+++ b/src/matrix/room/RoomSummary.ts
@@ -216,6 +216,7 @@ export type SerializedSummaryData = {
     tags?: Content;
     isDirectMessage: boolean;
     dmUserId?: string;
+    isSpace: boolean;
 }
 
 export class SummaryData {
@@ -238,27 +239,29 @@ export class SummaryData {
     isDirectMessage: boolean;
     dmUserId?: string;
     cloned?: boolean;
+    isSpace: boolean;
 
-    constructor(copy?: SummaryData, roomId?: string) {
-        this.roomId = copy?.roomId ?? roomId;
+    constructor(copy?: SummaryData | SerializedSummaryData, roomId?: string, isSpace?: boolean) {
+        this.roomId = copy?.roomId || roomId;
         this.name = copy?.name;
         this.lastMessageTimestamp = copy?.lastMessageTimestamp;
         this.isUnread = copy ? copy.isUnread : false;
         this.encryption = copy?.encryption;
         this.membership = copy?.membership;
-        this.inviteCount = copy?.inviteCount ?? 0;
-        this.joinCount = copy?.joinCount ?? 0;
+        this.inviteCount = copy?.inviteCount || 0;
+        this.joinCount = copy?.joinCount || 0;
         this.heroes = copy?.heroes;
         this.canonicalAlias = copy?.canonicalAlias;
-        this.hasFetchedMembers = copy?.hasFetchedMembers ?? false;
-        this.isTrackingMembers = copy?.isTrackingMembers ?? false;
+        this.hasFetchedMembers = copy?.hasFetchedMembers || false;
+        this.isTrackingMembers = copy?.isTrackingMembers || false;
         this.avatarUrl = copy?.avatarUrl;
-        this.notificationCount = copy?.notificationCount ?? 0;
-        this.highlightCount = copy?.highlightCount ?? 0;
+        this.notificationCount = copy?.notificationCount || 0;
+        this.highlightCount = copy?.highlightCount || 0;
         this.tags = copy?.tags;
-        this.isDirectMessage = copy?.isDirectMessage ?? false;
+        this.isDirectMessage = copy?.isDirectMessage || false;
         this.dmUserId = copy?.dmUserId;
         this.cloned = copy ? true : false;
+        this.isSpace = copy ? copy.isSpace : isSpace ?? false;
     }
 
     changedKeys(other: { [x: string]: any; }): string[] {
@@ -305,8 +308,8 @@ export class SummaryData {
 export class RoomSummary {
     private _data: SummaryData;
 
-	constructor(roomId: string) {
-        this.applyChanges(new SummaryData(undefined, roomId));
+	constructor(roomId: string, isSpace?: boolean) {
+        this.applyChanges(new SummaryData(undefined, roomId, isSpace));
 	}
 
     get data(): SummaryData {
@@ -376,7 +379,7 @@ export class RoomSummary {
         this._data.cloned = false;
     }
 
-	async load(summary: SummaryData) {
+	async load(summary: SummaryData | SerializedSummaryData) {
         this.applyChanges(new SummaryData(summary));
 	}
 }

--- a/src/matrix/room/RoomSummary.ts
+++ b/src/matrix/room/RoomSummary.ts
@@ -238,27 +238,27 @@ export class SummaryData {
     tags?: Content;
     isDirectMessage: boolean;
     dmUserId?: string;
-    cloned?: boolean;
+    cloned: boolean;
     isSpace: boolean;
 
     constructor(copy?: SummaryData | SerializedSummaryData, roomId?: string, isSpace?: boolean) {
-        this.roomId = copy?.roomId || roomId;
+        this.roomId = copy?.roomId ?? roomId;
         this.name = copy?.name;
         this.lastMessageTimestamp = copy?.lastMessageTimestamp;
         this.isUnread = copy ? copy.isUnread : false;
         this.encryption = copy?.encryption;
         this.membership = copy?.membership;
-        this.inviteCount = copy?.inviteCount || 0;
-        this.joinCount = copy?.joinCount || 0;
+        this.inviteCount = copy?.inviteCount ?? 0;
+        this.joinCount = copy?.joinCount ?? 0;
         this.heroes = copy?.heroes;
         this.canonicalAlias = copy?.canonicalAlias;
-        this.hasFetchedMembers = copy?.hasFetchedMembers || false;
-        this.isTrackingMembers = copy?.isTrackingMembers || false;
+        this.hasFetchedMembers = copy?.hasFetchedMembers ?? false;
+        this.isTrackingMembers = copy?.isTrackingMembers ?? false;
         this.avatarUrl = copy?.avatarUrl;
-        this.notificationCount = copy?.notificationCount || 0;
-        this.highlightCount = copy?.highlightCount || 0;
+        this.notificationCount = copy?.notificationCount ?? 0;
+        this.highlightCount = copy?.highlightCount ?? 0;
         this.tags = copy?.tags;
-        this.isDirectMessage = copy?.isDirectMessage || false;
+        this.isDirectMessage = copy?.isDirectMessage ?? false;
         this.dmUserId = copy?.dmUserId;
         this.cloned = copy ? true : false;
         this.isSpace = copy ? copy.isSpace : isSpace ?? false;

--- a/src/matrix/room/Space.ts
+++ b/src/matrix/room/Space.ts
@@ -1,0 +1,16 @@
+import { RoomEventType } from "../net/types/roomEvents";
+import { ClientEventWithoutRoomID } from "../net/types/sync";
+import { Room, Options as RoomOptions } from "./Room";
+
+/**
+ * Space is technically just a special type of Room per matrix spec definitions
+ */
+export class Space extends Room {
+  constructor(options: RoomOptions) {
+    super({...options, isSpace: true})
+  }
+}
+
+export function isSpaceCreateEvent(event: ClientEventWithoutRoomID): boolean {
+  return event.type === RoomEventType.Create && event.content.type === "m.space"
+}

--- a/src/matrix/room/timeline/persistence/MemberWriter.ts
+++ b/src/matrix/room/timeline/persistence/MemberWriter.ts
@@ -104,7 +104,6 @@ export class MemberSync {
         return members;
     }
 
-    // TODO: timelineEvents: TimelineEvent[] seems like it would make more sense but TimelineEvent doesn't have state_key
     _timelineEventsToMembers(timelineEvents: ClientEventWithoutRoomID[]): Map<string, RoomMember> | undefined {
         let members: Map<string, RoomMember> | undefined;
         // iterate backwards to only add the last member in the timeline

--- a/src/matrix/room/timeline/persistence/common.ts
+++ b/src/matrix/room/timeline/persistence/common.ts
@@ -17,20 +17,20 @@ limitations under the License.
 import { EventKey } from "../EventKey";
 import type { Direction } from "../Direction";
 
-type EventEnry = {
+type EventEntry<T = any> = {
     fragmentId: number;
     eventIndex: number;
     roomId: string;
-    event: any;
+    event: T;
     displayName?: string;
     avatarUrl?: string;
 };
 
-export function createEventEntry(
+export function createEventEntry<T = any>(
     key: EventKey,
     roomId: string,
-    event: any
-): EventEnry {
+    event: T,
+): EventEntry<T> {
     return {
         fragmentId: key.fragmentId,
         eventIndex: key.eventIndex,


### PR DESCRIPTION
Adds the concept of a `Space` to the sync process.

In memory, spaces are stored in `Session._spaces` as an `ObservableMap<string, Space>;`, just like how rooms are stored at `Session._rooms`.

On disk, spaces are stored exactly how rooms are stored. All that has been changed is that the data saved to the `RoomSummaryStore` has been given an additional `isSpace` boolean value.

Now that I'm writing this out, I think that the approach of storing spaces exactly how rooms are stored in the `RoomSummaryStore` is the wrong one. Currently it only adds a single `isSpace` boolean value, however in the future we may wish to add information to the schema that's only applicable to either rooms or spaces (and likely there's already some info that's already only applicable to rooms in there). This of course could be done by simply leaving that respective information out for some entries, but at that point the code becomes ugly and cumbersome to work with. Better to create a `SpaceSummaryStore` here at the offset.