### PR TITLE
`IRoomManager`

### DIFF
--- a/doc/SDK.md
+++ b/doc/SDK.md
@@ -33,6 +33,7 @@ import {
     RoomViewModel,
     TimelineView,
     viewClassForTile
+    getDefaultRoomManagers
 } from "hydrogen-view-sdk";
 import downloadSandboxPath from 'hydrogen-view-sdk/download-sandbox.html?url';
 import workerPath from 'hydrogen-view-sdk/main.js?url';
@@ -62,7 +63,7 @@ async function main() {
         history: platform.history
     });
     urlRouter.attach();
-    const client = new Client(platform);
+    const client = new Client(this.platform, getDefaultRoomManagers());
 
     const loginOptions = await client.queryLogin("matrix.org").result;
     client.startWithLogin(loginOptions.password("username", "password"));

--- a/src/domain/ForcedLogoutViewModel.ts
+++ b/src/domain/ForcedLogoutViewModel.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import {Options as BaseOptions, ViewModel} from "./ViewModel";
 import {Client} from "../matrix/Client";
 import {SegmentType} from "./navigation/index";
+import { getDefaultRoomManagers } from "../matrix/room/RoomManager";
 
 type Options = { sessionId: string; } & BaseOptions;
 
@@ -36,7 +37,7 @@ export class ForcedLogoutViewModel extends ViewModel<SegmentType, Options> {
 
     async forceLogout(): Promise<void> {
         try {
-            const client = new Client(this.platform);
+            const client = new Client(this.platform, getDefaultRoomManagers());
             await client.startForcedLogout(this._sessionId);
         }
         catch (err) {

--- a/src/domain/LogoutViewModel.ts
+++ b/src/domain/LogoutViewModel.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import {Options as BaseOptions, ViewModel} from "./ViewModel";
 import {Client} from "../matrix/Client";
 import {SegmentType} from "./navigation/index";
+import { getDefaultRoomManagers } from "../matrix/room/RoomManager";
 
 type Options = { sessionId: string; } & BaseOptions;
 
@@ -51,7 +52,7 @@ export class LogoutViewModel extends ViewModel<SegmentType, Options> {
         this._showConfirm = false;
         this.emitChange("busy");
         try {
-            const client = new Client(this.platform);
+            const client = new Client(this.platform, getDefaultRoomManagers());
             await client.startLogout(this._sessionId);
             this.navigation.push("session", true);
         } catch (err) {

--- a/src/domain/RootViewModel.ts
+++ b/src/domain/RootViewModel.ts
@@ -22,6 +22,7 @@ import {LogoutViewModel} from "./LogoutViewModel";
 import {ForcedLogoutViewModel} from "./ForcedLogoutViewModel";
 import {SessionPickerViewModel} from "./SessionPickerViewModel";
 import {ViewModel, Options as ViewModelOptions} from "./ViewModel";
+import { getDefaultRoomManagers } from "../matrix/room/RoomManager";
 
 export class RootViewModel extends ViewModel {
     private _error?: any;
@@ -160,7 +161,7 @@ export class RootViewModel extends ViewModel {
     }
 
     _showSessionLoader(sessionId: string) {
-        const client = new Client(this.platform);
+        const client = new Client(this.platform, getDefaultRoomManagers());
         client.startWithExistingSession(sessionId);
         this._setSection(() => {
             this._sessionLoadViewModel = new SessionLoadViewModel(this.childOptions({

--- a/src/domain/login/LoginViewModel.ts
+++ b/src/domain/login/LoginViewModel.ts
@@ -24,6 +24,7 @@ import {SessionLoadViewModel} from "../SessionLoadViewModel";
 import {SegmentType} from "../navigation/index";
 
 import type {PasswordLoginMethod, SSOLoginHelper, TokenLoginMethod, ILoginMethod} from "../../matrix/login";
+import { getDefaultRoomManagers } from "../../matrix/room/RoomManager";
 
 export type Options = {
     defaultHomeserver: string;
@@ -55,7 +56,7 @@ export class LoginViewModel extends ViewModel<SegmentType, Options> {
         const {ready, defaultHomeserver, loginToken} = options;
         this._ready = ready;
         this._loginToken = loginToken;
-        this._client = new Client(this.platform);
+        this._client = new Client(this.platform, getDefaultRoomManagers());
         this._homeserver = defaultHomeserver;
         this._initViewModels();
     }

--- a/src/domain/session/SessionViewModel.ts
+++ b/src/domain/session/SessionViewModel.ts
@@ -33,7 +33,7 @@ import {SyncStatus} from "../../matrix/Sync";
 
 import type {Options as ViewModelOptions} from "../ViewModel";
 import type {Client} from "../../matrix/Client";
-import type {Room} from "../../matrix/room/Room";
+import type {InstantMessageRoom} from "../../matrix/room/InstantMessageRoom";
 import type {IGridItemViewModel} from "./room/IGridItemViewModel";
 
 type Options = {
@@ -345,7 +345,7 @@ export class SessionViewModel extends ViewModel {
         return this._lightboxViewModel;
     }
 
-    _roomFromNavigation(): Room | undefined {
+    _roomFromNavigation(): InstantMessageRoom | undefined {
         const roomId = this.navigation.path.get("room")?.value;
         const room = this.client.session.rooms?.get(roomId);
         return room;

--- a/src/domain/session/leftpanel/LeftPanelViewModel.ts
+++ b/src/domain/session/leftpanel/LeftPanelViewModel.ts
@@ -24,7 +24,7 @@ import { RoomFilter } from "./RoomFilter";
 import { ApplyMap, MappedMap, ObservableMap } from "../../../observable/";
 import { SortedMapList } from "../../../observable//list/SortedMapList";
 import { addPanelIfNeeded } from "../../navigation/index";
-import { Room } from "../../../matrix/room/Room";
+import { InstantMessageRoom } from "../../../matrix/room/InstantMessageRoom";
 import { Invite } from "../../../matrix/room/Invite";
 import { RoomBeingCreated } from "../../../matrix/room/RoomBeingCreated";
 import { Session } from "../../../matrix/Session";
@@ -40,7 +40,7 @@ export class LeftPanelViewModel extends ViewModel<
     private _currentTileVM?: BaseTileViewModel;
     private _tileViewModelsMap: MappedMap<
         string,
-        RoomBeingCreated | Invite | Room,
+        RoomBeingCreated | Invite | InstantMessageRoom,
         BaseTileViewModel
     >;
     private _tileViewModelsFilterMap: ApplyMap<string, BaseTileViewModel>;
@@ -71,12 +71,12 @@ export class LeftPanelViewModel extends ViewModel<
     _mapTileViewModels(
         roomsBeingCreated: ObservableMap<string, RoomBeingCreated>,
         invites: ObservableMap<string, Invite>,
-        rooms: ObservableMap<string, Room>
-    ): MappedMap<string, RoomBeingCreated | Invite | Room, BaseTileViewModel> {
+        rooms: ObservableMap<string, InstantMessageRoom>
+    ): MappedMap<string, RoomBeingCreated | Invite | InstantMessageRoom, BaseTileViewModel> {
         // join is not commutative, invites will take precedence over rooms
         const allTiles = invites
             .join(roomsBeingCreated, rooms)
-            .mapValues((item: RoomBeingCreated | Invite | Room, emitChange) => {
+            .mapValues((item: RoomBeingCreated | Invite | InstantMessageRoom, emitChange) => {
                 let vm: BaseTileViewModel;
                 if (item.isBeingCreated) {
                     vm = new RoomBeingCreatedTileViewModel(
@@ -94,7 +94,7 @@ export class LeftPanelViewModel extends ViewModel<
                     );
                 } else {
                     vm = new RoomTileViewModel(
-                        this.childOptions({ room: item as Room, emitChange })
+                        this.childOptions({ room: item as InstantMessageRoom, emitChange })
                     );
                 }
                 const isOpen =

--- a/src/domain/session/leftpanel/RoomTileViewModel.ts
+++ b/src/domain/session/leftpanel/RoomTileViewModel.ts
@@ -16,15 +16,15 @@ limitations under the License.
 */
 import {BaseTileViewModel, Kind, AvatarSource} from "./BaseTileViewModel";
 import {Options as ViewModelOptions} from "../../ViewModel";
-import {Room} from "../../../matrix/room/Room";
+import {InstantMessageRoom} from "../../../matrix/room/InstantMessageRoom";
 
 
 type Options = {
-    room: Room;
+    room: InstantMessageRoom;
 } & ViewModelOptions;
 
 export class RoomTileViewModel extends BaseTileViewModel {
-    private readonly _room: Room;
+    private readonly _room: InstantMessageRoom;
     private _url: string;
 
     constructor(options: Readonly<Options>) {

--- a/src/domain/session/rightpanel/RightPanelViewModel.ts
+++ b/src/domain/session/rightpanel/RightPanelViewModel.ts
@@ -23,18 +23,18 @@ import {MemberListViewModel} from "./MemberListViewModel";
 import type {ExplicitOptions as MemberListViewModelOptions} from "./MemberListViewModel";
 import {MemberDetailsViewModel} from "./MemberDetailsViewModel";
 import type {ExplicitOptions as MemberDetailsViewModelOptions} from "./MemberDetailsViewModel";
-import type {Room} from "../../../matrix/room/Room";
+import type {InstantMessageRoom} from "../../../matrix/room/InstantMessageRoom";
 import type {Session} from "../../../matrix/Session";
 import type {MemberList} from "../../../matrix/room/members/MemberList";
 
 
 type Options = {
-    room: Room,
+    room: InstantMessageRoom,
     session: Session,
 } & BaseOptions;
 
 export class RightPanelViewModel extends ViewModel {
-    private _room: Room;
+    private _room: InstantMessageRoom;
     private _session: Session;
     private _members?: MemberList;
     private _activeViewModel?: ActiveViewModel;

--- a/src/domain/session/rightpanel/RoomDetailsViewModel.ts
+++ b/src/domain/session/rightpanel/RoomDetailsViewModel.ts
@@ -17,15 +17,15 @@ limitations under the License.
 import {ViewModel} from "../../ViewModel";
 import type {Options as BaseOptions} from "../../ViewModel";
 import type {SegmentType} from "../../navigation";
-import type {Room} from "../../../matrix/room/Room";
+import type {InstantMessageRoom} from "../../../matrix/room/InstantMessageRoom";
 import {avatarInitials, getIdentifierColorNumber, getAvatarHttpUrl} from "../../avatar";
 
-export type ExplicitOptions = { room: Room };
+export type ExplicitOptions = { room: InstantMessageRoom };
 
 type Options = ExplicitOptions & BaseOptions;
 
 export class RoomDetailsViewModel extends ViewModel {
-    private _room: Room
+    private _room: InstantMessageRoom
 
     constructor(options: Options) {
         super(options);

--- a/src/domain/session/room/LightboxViewModel.ts
+++ b/src/domain/session/room/LightboxViewModel.ts
@@ -16,13 +16,13 @@ limitations under the License.
 
 import {ViewModel} from "../../ViewModel";
 import type {Options as ViewModelOptions} from "../../ViewModel";
-import type {Room} from "../../../matrix/room/Room";
+import type {InstantMessageRoom} from "../../../matrix/room/InstantMessageRoom";
 import type {EventEntry} from "../../../matrix/room/timeline/entries/EventEntry";
 import type {BlobHandle} from "../../../platform/web/dom/BlobHandle";
 
 type Options = {
     eventId: string;
-    room: Room;
+    room: InstantMessageRoom;
 } & ViewModelOptions
 
 export class LightboxViewModel extends ViewModel {
@@ -41,7 +41,7 @@ export class LightboxViewModel extends ViewModel {
         this._subscribeToEvent(options.room, options.eventId);
     }
 
-    _subscribeToEvent(room: Room, eventId: string): void {
+    _subscribeToEvent(room: InstantMessageRoom, eventId: string): void {
         const eventObservable = room.observeEvent(eventId);
         this.track(eventObservable.subscribe(eventEntry => {
             void this._loadEvent(room, eventEntry);
@@ -49,7 +49,7 @@ export class LightboxViewModel extends ViewModel {
         void this._loadEvent(room, eventObservable.get());
     }
 
-    async _loadEvent(room: Room, eventEntry: any | null): Promise<void> {
+    async _loadEvent(room: InstantMessageRoom, eventEntry: any | null): Promise<void> {
         if (!eventEntry) {
             return;
         }

--- a/src/domain/session/room/RoomViewModel.ts
+++ b/src/domain/session/room/RoomViewModel.ts
@@ -26,7 +26,7 @@ import {imageToInfo, MultiMediaInfo} from "../common";
 import {tileClassForEntry as defaultTileClassForEntry, TimelineEntry} from "./timeline/tiles/index";
 import {joinRoom} from "../../../matrix/room/joinRoom";
 
-import type {Room} from "../../../matrix/room/Room";
+import type {InstantMessageRoom} from "../../../matrix/room/InstantMessageRoom";
 import type {ArchivedRoom} from "../../../matrix/room/ArchivedRoom";
 import type {TileClassForEntryFn, Options as TileOptions} from "./timeline/tiles";
 import type {SimpleTile} from "./timeline/tiles/SimpleTile";
@@ -38,13 +38,13 @@ import type {Options as ViewModelOptions} from "../../ViewModel";
 
 type Options = {
     client?: Client;
-    room: Room,
+    room: InstantMessageRoom,
     tileClassForEntry?: TileClassForEntryFn
 } & ViewModelOptions;
 
 export class RoomViewModel extends ViewModel implements IGridItemViewModel {
     private _client?: Client;
-    private _room: Room;
+    private _room: InstantMessageRoom;
     private _tileClassForEntry: TileClassForEntryFn;
     private _composerVM?: InternalViewModel;
     private _timelineVM?: TimelineViewModel;
@@ -424,7 +424,7 @@ export class RoomViewModel extends ViewModel implements IGridItemViewModel {
         }
     }
 
-    get room(): Room {
+    get room(): InstantMessageRoom {
         return this._room;
     }
 
@@ -460,7 +460,7 @@ function videoToInfo(video: VideoHandle): MultiMediaInfo {
 }
 
 type ArchivedViewModelOptions = {
-    archivedRoom: Room;
+    archivedRoom: InstantMessageRoom;
 } & ViewModelOptions;
 
 class ArchivedViewModel extends ViewModel {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -18,6 +18,7 @@ export {Platform} from "./platform/web/Platform";
 export {Client, LoadStatus} from "./matrix/Client";
 export {RoomStatus} from "./matrix/room/common";
 export {PowerLevels} from "./matrix/room/PowerLevels.js";
+export {getDefaultRoomManagers} from "./matrix/room/RoomManager";
 // export main view & view models
 export {createNavigation, createRouter} from "./domain/navigation/index";
 export {RootViewModel} from "./domain/RootViewModel";

--- a/src/matrix/Client.ts
+++ b/src/matrix/Client.ts
@@ -40,6 +40,8 @@ import type {SubscriptionHandle} from "../observable/BaseObservable";
 import type {EncryptedDehydratedDevice} from "./e2ee/Dehydration";
 import type {IHomeServerRequest} from "./net/HomeServerRequest";
 import type {ISessionInfo} from "./sessioninfo/localstorage/SessionInfoStorage";
+import { InstantMessageRoom } from "./room/InstantMessageRoom";
+import { InstantMessageRoomManager } from "./room/InstantMessageRoomManager";
 
 export enum LoadStatus {
     NotLoading = "NotLoading",
@@ -307,6 +309,7 @@ export class Client {
             olmWorker,
             mediaRepository,
             platform: this._platform,
+            roomManagers: new Map([['imRooms', new InstantMessageRoomManager()]]) // todo(isaiah): make these configurable via the Client's constructor
         });
         await this._session.load(log);
         if (dehydratedDevice) {

--- a/src/matrix/Client.ts
+++ b/src/matrix/Client.ts
@@ -42,6 +42,7 @@ import type {IHomeServerRequest} from "./net/HomeServerRequest";
 import type {ISessionInfo} from "./sessioninfo/localstorage/SessionInfoStorage";
 import { InstantMessageRoom } from "./room/InstantMessageRoom";
 import { InstantMessageRoomManager } from "./room/InstantMessageRoomManager";
+import { IRoomManager } from "./room/RoomManager";
 
 export enum LoadStatus {
     NotLoading = "NotLoading",
@@ -80,13 +81,15 @@ export class Client {
     private _accountSetup?: AccountSetup;
     private _reconnectSubscription?: SubscriptionHandle;
     private _waitForFirstSyncHandle?: IWaitHandle<SyncStatus>;
+    private _roomManagers: Map<string, IRoomManager<any, any, any>>;
 
-    constructor(platform: Platform) {
+    constructor(platform: Platform, roomManagers: Map<string, IRoomManager<any, any, any>>) {
         this._platform = platform;
         this._sessionStartedByReconnector = false;
         this._status = new ObservableValue(LoadStatus.NotLoading);
         this._olmPromise = platform.loadOlm();
         this._workerPromise = platform.loadOlmWorker();
+        this._roomManagers = roomManagers;
     }
 
     createNewSessionId(): string {
@@ -309,7 +312,7 @@ export class Client {
             olmWorker,
             mediaRepository,
             platform: this._platform,
-            roomManagers: new Map([['imRooms', new InstantMessageRoomManager()]]) // todo(isaiah): make these configurable via the Client's constructor
+            roomManagers: this._roomManagers,
         });
         await this._session.load(log);
         if (dehydratedDevice) {

--- a/src/matrix/Sync.ts
+++ b/src/matrix/Sync.ts
@@ -15,9 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {ObservableValue} from "../observable/ObservableValue";
+import {ObservableValue, RetainedObservableValue} from "../observable/ObservableValue";
 
-import type {Room, RoomSyncPreparation, RoomWriteSyncChanges} from "./room/Room";
+import type {InstantMessageRoom, InstantMessageRoomPreparation, InstantMessageRoomWriteChanges} from "./room/InstantMessageRoom";
 import type {LogItem} from "../logging/LogItem";
 import type {ILogger, ILogItem} from "../logging/types";
 import type {HomeServerApi} from "./net/HomeServerApi";
@@ -32,6 +32,7 @@ import type {ArchivedRoom} from "./room/ArchivedRoom";
 import type {Invite} from "./room/Invite";
 import type {Transaction} from "./storage/idb/Transaction";
 import { Membership } from "./net/types/roomEvents";
+import { RoomStatus } from "./room/common";
 
 const INCREMENTAL_TIMEOUT = 30000;
 
@@ -42,7 +43,7 @@ export enum SyncStatus {
     Stopped = "Stopped"
 }
 
-function timelineIsEmpty(roomResponse: JoinedRoom | LeftRoom): boolean {
+export function timelineIsEmpty(roomResponse: JoinedRoom | LeftRoom): boolean {
     try {
         const events = roomResponse?.timeline?.events;
         return Array.isArray(events) && events.length === 0;
@@ -116,7 +117,6 @@ export class Sync {
     async _syncLoop(syncToken?: string): Promise<void> {
         // if syncToken is falsy, it will first do an initial sync ...
         while(this._status.get() !== SyncStatus.Stopped) {
-            let roomStates: RoomSyncProcessState[];
             let sessionChanges: Changes | undefined;
             let wasCatchupOrInitial = this._status.get() === SyncStatus.CatchupSync || this._status.get() === SyncStatus.InitialSync;
             await this._logger.run("sync", async log => {
@@ -137,7 +137,6 @@ export class Sync {
                     const timeout = this._status.get() === SyncStatus.Syncing ? INCREMENTAL_TIMEOUT : 0;
                     const syncResult = await this._syncRequest(syncToken, timeout, log);
                     syncToken = syncResult.syncToken;
-                    roomStates = syncResult.roomStates;
                     sessionChanges = syncResult.sessionChanges;
                     // initial sync or catchup sync
                     if (this._status.get() !== SyncStatus.Syncing && syncResult.hadToDeviceMessages) {
@@ -167,7 +166,7 @@ export class Sync {
                     // should we move this inside _syncRequest?
                     // Alternatively, we can try to fix the OTK upload issue while still
                     // running in parallel.
-                    await log.wrap("afterSyncCompleted", log => this._runAfterSyncCompleted(sessionChanges, roomStates, log));
+                    await log.wrap("afterSyncCompleted", log => this._afterSyncCompleted(sessionChanges, log));
                 }
             },
             this._logger.level.Info,
@@ -181,24 +180,14 @@ export class Sync {
         }
     }
 
-    async _runAfterSyncCompleted(sessionChanges: Changes | undefined, roomStates: RoomSyncProcessState[], log: ILogItem): Promise<void> {
+    async _afterSyncCompleted(sessionChanges: Changes | undefined, log: ILogItem): Promise<void> {
         const isCatchupSync = this._status.get() === SyncStatus.CatchupSync;
-        const sessionPromise = (async () => {
-            try {
-                await log.wrap("session", log => this._session.afterSyncCompleted(sessionChanges, isCatchupSync, log));
-            } catch (err) {} // error is logged, but don't fail sessionPromise
-        })();
-        const roomsPromises = roomStates.map(async rs => {
-            try {
-                if (!rs.changes) throw new Error("missing changes")
-                await rs.room.afterSyncCompleted(rs.changes, log);
-            } catch (err) {} // error is logged, but don't fail roomsPromises
-        });
-        // run everything in parallel,
-        // we don't want to delay the next sync too much
-        // Also, since all promises won't reject (as they have a try/catch)
-        // it's fine to use Promise.all
-        await Promise.all(roomsPromises.concat(sessionPromise));
+        try {
+            await log.wrap("session", log => this._session.afterSyncCompleted(sessionChanges, isCatchupSync, log));
+        } catch (err) {} // error is logged, but don't fail sessionPromise
+        for (const roomTypeManager of this._session.roomManagers.values()) {
+            await roomTypeManager.afterSyncCompleted(log);
+        }
     }
 
     async _syncRequest(
@@ -207,7 +196,6 @@ export class Sync {
         log: ILogItem
       ): Promise<{
         syncToken: string;
-        roomStates: RoomSyncProcessState[];
         sessionChanges?: Changes;
         hadToDeviceMessages: boolean;
       }> {
@@ -222,31 +210,26 @@ export class Sync {
 
         const isInitialSync = !syncToken;
         const sessionState = new SessionSyncProcessState();
-        const inviteStates = this._parseInvites(response.rooms);
-        const {roomStates, archivedRoomStates} = await this._parseRoomsResponse(
-            response.rooms, inviteStates, isInitialSync, log);
+
+        for (const roomTypeManager of this._session.roomManagers.values()) {
+            await roomTypeManager.initSync(response.rooms, isInitialSync, log);
+        }
 
         try {
             // take a lock on olm sessions used in this sync so sending a message doesn't change them while syncing
             sessionState.lock = await log.wrap("obtainSyncLock", () => this._session.obtainSyncLock(response));
-            await log.wrap("prepare", log => this._prepareSync(sessionState, roomStates, response, log));
-            await log.wrap("afterPrepareSync", log => Promise.all(roomStates.map(rs => {
-                return rs.room.afterPrepareSync(rs.preparation, log);
-            })));
-            await log.wrap("write", async log => this._writeSync(
-                sessionState, inviteStates, roomStates, archivedRoomStates,
-                response, syncFilterId, isInitialSync, log));
+            await log.wrap("prepare", log => this._prepareSync(sessionState, response, log));
+            await log.wrap("afterPrepareSync", log => this._afterPrepareSync(log));
+            await log.wrap("write", async log => this._writeSync(sessionState, response, syncFilterId, isInitialSync, log));
         } finally {
             sessionState.dispose();
         }
         // sync txn comitted, emit updates and apply changes to in-memory state
-        log.wrap("after", log => this._afterSync(
-            sessionState, inviteStates, roomStates, archivedRoomStates, log));
+        log.wrap("after", log => this._afterSync(sessionState, log));
 
         const toDeviceEvents = response.to_device?.events;
         return {
             syncToken: response.next_batch,
-            roomStates,
             sessionChanges: sessionState.changes,
             hadToDeviceMessages: Array.isArray(toDeviceEvents) && toDeviceEvents.length > 0,
         };
@@ -254,131 +237,75 @@ export class Sync {
 
     _openPrepareSyncTxn(): Promise<Transaction> {
         const storeNames = this._storage.storeNames;
-        return this._storage.readTxn([
-            storeNames.olmSessions,
-            storeNames.inboundGroupSessions,
-            // to read fragments when loading sync writer when rejoining archived room
-            storeNames.timelineFragments,
-            // to read fragments when loading sync writer when rejoining archived room
-            // to read events that can now be decrypted
-            storeNames.timelineEvents,
-        ]);
+        let prepareSyncStoreNames: string[] = [storeNames.olmSessions];
+        for (const roomTypeManager of this._session.roomManagers.values()) {
+            prepareSyncStoreNames = [...prepareSyncStoreNames, ...roomTypeManager.storesForPrepareSync]
+        }
+        // dedup just in case
+        prepareSyncStoreNames = [...new Set(prepareSyncStoreNames)];
+
+        return this._storage.readTxn(prepareSyncStoreNames);
     }
 
-    async _prepareSync(sessionState: SessionSyncProcessState, roomStates: RoomSyncProcessState[], response: SyncResponse, log: ILogItem): Promise<void> {
+    async _prepareSync(sessionState: SessionSyncProcessState, syncResponse: SyncResponse, log: ILogItem): Promise<void> {
         const prepareTxn = await this._openPrepareSyncTxn();
         sessionState.preparation = await log.wrap("session", log => this._session.prepareSync(
-            response, sessionState.lock, prepareTxn, log));
+            syncResponse, sessionState.lock, prepareTxn, log));
 
         const newKeysByRoom = sessionState.preparation?.newKeysByRoom;
 
-        // add any rooms with new keys but no sync response to the list of rooms to be synced
-        if (newKeysByRoom) {
-            const {hasOwnProperty} = Object.prototype;
-            for (const roomId of newKeysByRoom.keys()) {
-                const isRoomInResponse = response.rooms?.join && hasOwnProperty.call(response.rooms.join, roomId);
-                if (!isRoomInResponse) {
-                    let room = this._session.rooms?.get(roomId);
-                    if (room) {
-                        roomStates.push(new RoomSyncProcessState(room, false, {}, room.membership));
-                    }
-                }
-            }
+        for (const roomTypeManager of this._session.roomManagers.values()) {
+            await roomTypeManager.prepareSync(syncResponse.rooms, newKeysByRoom, prepareTxn, log);
         }
-
-        await Promise.all(roomStates.map(async rs => {
-            const newKeys = newKeysByRoom?.get(rs.room.id) ?? [];
-            rs.preparation = await log.wrap("room", async log => {
-                // if previously joined and we still have the timeline for it,
-                // this loads the syncWriter at the correct position to continue writing the timeline
-                if (rs.isNewRoom) {
-                    await rs.room.load(undefined, prepareTxn, log);
-                }
-                return rs.room.prepareSync(
-                    rs.roomResponse, rs.membership, newKeys, prepareTxn, log);
-            }, log.level.Detail);
-        }));
 
         // This is needed for safari to not throw TransactionInactiveErrors on the syncTxn. See docs/INDEXEDDB.md
         await prepareTxn.complete();
     }
 
+    async _afterPrepareSync(log: ILogItem) {
+        for (const roomTypeManager of this._session.roomManagers.values()) {
+            await roomTypeManager.afterPrepareSync(log);
+        }
+    }
+
     async _writeSync(
         sessionState: SessionSyncProcessState,
-        inviteStates: InviteSyncProcessState[],
-        roomStates: RoomSyncProcessState[],
-        archivedRoomStates: ArchivedRoomSyncProcessState[],
         response: SyncResponse,
         syncFilterId: number | undefined,
         isInitialSync: boolean,
         log: ILogItem,
       ): Promise<void> {
-        const syncTxn = await this._openSyncTxn();
+        const writeSyncTxn = await this._openWriteSyncTxn();
         try {
             sessionState.changes = await log.wrap("session", log => this._session.writeSync(
-                response, syncFilterId, sessionState.preparation, syncTxn, log));
-            await Promise.all(inviteStates.map(async is => {
-                is.changes = await log.wrap("invite", log => is.invite.writeSync(
-                    is.membership, is.roomResponse, syncTxn, log));
-            }));
-            await Promise.all(roomStates.map(async rs => {
-                rs.changes = await log.wrap("room", log => rs.room.writeSync(
-                    rs.roomResponse, isInitialSync, rs.preparation!, syncTxn, log));
-            }));
-            // important to do this after roomStates,
-            // as we're referring to the roomState to get the summaryChanges
-            await Promise.all(archivedRoomStates.map(async ars => {
-                const summaryChanges = ars.roomState?.summaryChanges;
-                ars.changes = await log.wrap("archivedRoom", log => ars.archivedRoom.writeSync(
-                    summaryChanges, ars.roomResponse, ars.membership, syncTxn, log));
-            }));
+                response, syncFilterId, sessionState.preparation, writeSyncTxn, log));
+            for (const roomTypeManager of this._session.roomManagers.values()) {
+                await roomTypeManager.writeSync(writeSyncTxn, isInitialSync, log);
+            }
         } catch(err) {
             // avoid corrupting state by only
             // storing the sync up till the point
             // the exception occurred
-            syncTxn.abort(log);
-            throw syncTxn.getCause(err);
+            writeSyncTxn.abort(log);
+            throw writeSyncTxn.getCause(err);
         }
-        await syncTxn.complete(log);
+        await writeSyncTxn.complete(log);
     }
 
-    _afterSync(
+    async _afterSync(
         sessionState: SessionSyncProcessState,
-        inviteStates: InviteSyncProcessState[],
-        roomStates: RoomSyncProcessState[],
-        archivedRoomStates: ArchivedRoomSyncProcessState[],
         log: ILogItem
-      ): void {
+    ): Promise<void> {
         log.wrap("session", log => this._session.afterSync(sessionState.changes), log.level.Detail);
-        for(let ars of archivedRoomStates) {
-            log.wrap("archivedRoom", log => {
-                ars.archivedRoom.afterSync(ars.changes, log);
-                ars.archivedRoom.release();
-            }, log.level.Detail);
+        for (const roomTypeManager of this._session.roomManagers.values()) {
+            await roomTypeManager.afterSync(log);
         }
-        for(let rs of roomStates) {
-            if (!rs.changes) throw new Error("missing changes")
-            log.wrap("room", log => rs.room.afterSync(rs.changes!, log), log.level.Detail);
-        }
-        for(let is of inviteStates) {
-            log.wrap("invite", log => is.invite.afterSync(is.changes, log), log.level.Detail);
-        }
-        this._session.applyRoomCollectionChangesAfterSync(inviteStates, roomStates, archivedRoomStates, log);
     }
 
-    _openSyncTxn(): Promise<Transaction> {
+    _openWriteSyncTxn(): Promise<Transaction> {
         const storeNames = this._storage.storeNames;
-        return this._storage.readWriteTxn([
+        let writeSyncStoreNames: string[] = [
             storeNames.session,
-            storeNames.roomSummary,
-            storeNames.archivedRoomSummary,
-            storeNames.invites,
-            storeNames.roomState,
-            storeNames.roomMembers,
-            storeNames.timelineEvents,
-            storeNames.timelineRelations,
-            storeNames.timelineFragments,
-            storeNames.pendingEvents,
             storeNames.userIdentities,
             storeNames.groupSessionDecryptions,
             storeNames.deviceIdentities,
@@ -390,118 +317,13 @@ export class Sync {
             // to decrypt and store new room keys
             storeNames.olmSessions,
             storeNames.inboundGroupSessions,
-        ]);
-    }
-
-     async _parseRoomsResponse(
-        roomsSection: Rooms | undefined,
-        inviteStates: InviteSyncProcessState[],
-        isInitialSync: boolean,
-        log: ILogItem
-      ): Promise<{ roomStates: RoomSyncProcessState[]; archivedRoomStates: ArchivedRoomSyncProcessState[] }> {
-        const roomStates: RoomSyncProcessState[] = [];
-        const archivedRoomStates: ArchivedRoomSyncProcessState[] = [];
-        if (roomsSection) {
-            const allMemberships: ("join" | "leave")[] = ["join", "leave"];
-            for(const membership of allMemberships) {
-                const membershipSection = roomsSection[membership];
-                if (membershipSection) {
-                    for (const [roomId, _roomResponse] of Object.entries(membershipSection)) {
-                        const roomResponse: JoinedRoom | LeftRoom = _roomResponse;
-                        // ignore rooms with empty timelines during initial sync,
-                        // see https://github.com/vector-im/hydrogen-web/issues/15
-                        if (isInitialSync && timelineIsEmpty(roomResponse)) {
-                            continue;
-                        }
-                        const invite = this._session.invites.get(roomId);
-                        // if there is an existing invite, add a process state for it
-                        // so its writeSync and afterSync will run and remove the invite
-                        if (invite) {
-                            inviteStates.push(new InviteSyncProcessState(invite, false, undefined, membership));
-                        }
-                        const roomState = this._createRoomSyncState(roomId, roomResponse, membership, isInitialSync);
-                        if (roomState) {
-                            roomStates.push(roomState);
-                        }
-                        const ars = await this._createArchivedRoomSyncState(roomId, roomState, roomResponse, membership, isInitialSync, log);
-                        if (ars) {
-                            archivedRoomStates.push(ars);
-                        }
-                    }
-                }
-            }
+        ]
+        for (const roomTypeManager of this._session.roomManagers.values()) {
+            writeSyncStoreNames = [...writeSyncStoreNames, ...roomTypeManager.storesForWriteSync]
         }
-        return {roomStates, archivedRoomStates};
-    }
-
-    _createRoomSyncState(roomId: string, roomResponse: JoinedRoom | LeftRoom, membership: "join" | "leave", isInitialSync: boolean): RoomSyncProcessState | undefined {
-        let isNewRoom = false;
-        let room = this._session.rooms?.get(roomId);
-        // create room only either on new join,
-        // or for an archived room during initial sync,
-        // where we create the summaryChanges with a joined
-        // room to then adopt by the archived room.
-        // This way the limited timeline, members, ...
-        // we receive also gets written.
-        // In any case, don't create a room for a rejected invite
-        if (!room && (membership === "join" || (isInitialSync && membership === "leave"))) {
-            room = this._session.createJoinedRoom(roomId);
-            isNewRoom = true;
-        }
-        if (room) {
-            return new RoomSyncProcessState(
-                room, isNewRoom, roomResponse, membership);
-        }
-    }
-
-    async _createArchivedRoomSyncState(
-        roomId: string,
-        roomState: RoomSyncProcessState | undefined,
-        roomResponse: JoinedRoom | LeftRoom,
-        membership: 'join' | 'leave',
-        isInitialSync: boolean,
-        log: ILogItem
-      ): Promise<ArchivedRoomSyncProcessState | undefined> {
-        let archivedRoom: ArchivedRoom | undefined;
-        if (roomState?.shouldAdd && !isInitialSync) {
-            // when adding a joined room during incremental sync,
-            // always create the archived room to write the removal
-            // of the archived summary
-            archivedRoom = this._session.createOrGetArchivedRoomForSync(roomId);
-        } else if (membership === "leave") {
-            if (roomState) {
-                // we still have a roomState, so we just left it
-                // in this case, create a new archivedRoom
-                archivedRoom = this._session.createOrGetArchivedRoomForSync(roomId);
-            } else {
-                // this is an update of an already left room, restore
-                // it from storage first, so we can increment it.
-                // this happens for example when our membership changes
-                // after leaving (e.g. being (un)banned, possibly after being kicked), etc
-                archivedRoom = await this._session.loadArchivedRoom(roomId, log);
-            }
-        }
-        if (archivedRoom) {
-            return new ArchivedRoomSyncProcessState(
-                archivedRoom, roomState, roomResponse, membership);
-        }
-    }
-
-    _parseInvites(roomsSection?: Rooms): InviteSyncProcessState[] {
-        const inviteStates: InviteSyncProcessState[] = [];
-        if (roomsSection?.invite) {
-            for (const [roomId, _roomResponse] of Object.entries(roomsSection.invite)) {
-                const roomResponse = _roomResponse as InvitedRoom;
-                let invite = this._session.invites.get(roomId);
-                let isNewInvite = false;
-                if (!invite) {
-                    invite = this._session.createInvite(roomId);
-                    isNewInvite = true;
-                }
-                inviteStates.push(new InviteSyncProcessState(invite, isNewInvite, roomResponse, "invite"));
-            }
-        }
-        return inviteStates;
+        // dedup just in case
+        writeSyncStoreNames = [...new Set(writeSyncStoreNames)];
+        return this._storage.readWriteTxn(writeSyncStoreNames);
     }
 
     stop() {
@@ -525,121 +347,3 @@ class SessionSyncProcessState {
         this.lock?.release();
     }
 }
-
-export class RoomSyncProcessState {
-    /**
-     * @param {Object} roomResponse - a matrix Joined Room type or matrix Left Room type
-     */
-    room: Room;
-    isNewRoom: boolean;
-    roomResponse: JoinedRoom | LeftRoom;
-    membership?: Membership;
-    preparation?: RoomSyncPreparation;
-    changes?: RoomWriteSyncChanges;
-
-    constructor(room: Room, isNewRoom: boolean, roomResponse: JoinedRoom | LeftRoom, membership?: Membership) {
-        this.room = room;
-        this.isNewRoom = isNewRoom;
-        this.roomResponse = roomResponse;
-        this.membership = membership;
-    }
-
-    get id() {
-        return this.room.id;
-    }
-
-    get shouldAdd() {
-        return this.isNewRoom && this.membership === "join";
-    }
-
-    get shouldRemove() {
-        return !this.isNewRoom && this.membership !== "join";
-    }
-
-    get summaryChanges() {
-        return this.changes?.summaryChanges;
-    }
-}
-
-
-export class ArchivedRoomSyncProcessState {
-    archivedRoom: ArchivedRoom;
-    roomState: RoomSyncProcessState | undefined;
-    roomResponse: JoinedRoom | LeftRoom;
-    membership: "join" | "leave";
-    isInitialSync?: boolean;
-    changes?: {};
-
-    constructor(archivedRoom: ArchivedRoom, roomState: RoomSyncProcessState | undefined, roomResponse: JoinedRoom | LeftRoom, membership: "join" | "leave", isInitialSync?: boolean) {
-        this.archivedRoom = archivedRoom;
-        this.roomState = roomState;
-        this.roomResponse = roomResponse;
-        this.membership = membership;
-        this.isInitialSync = isInitialSync;
-    }
-
-    get id(): string {
-        return this.archivedRoom.id;
-    }
-
-    get shouldAdd(): boolean | undefined {
-        return (this.roomState || this.isInitialSync) && this.membership === "leave";
-    }
-
-    get shouldRemove(): boolean {
-        return this.membership === "join";
-    }
-}
-
-// TODO: move this to a more appropriate file
-// https://spec.matrix.org/v1.4/client-server-api/#mroomjoin_rules
-type JoinRule = "public" | "knock" | "invite" | "private" | "restricted"
-
-// TODO: move to Invite.js when that gets converted to typescript.
-// It's the return value of Invite._createData().
-type InviteData = {
-    roomId: string,
-    isEncrypted: boolean,
-    isDirectMessage: boolean,
-    name?: string,
-    avatarUrl?: string,
-    avatarColorId: string | null,
-    canonicalAlias: string | null,
-    timestamp: number,
-    joinRule: JoinRule | null,
-    inviter?: MemberData,
-}
-
-// TODO: move to Invite.js when that gets converted to typescript.
-// It's the return value of Invite.writeSync().
-type InviteWriteSyncChanges =
-  | { removed: true; membership: "join" | "leave" | "invite" }
-  | { inviteData: InviteData; inviter?: MemberData };
-
-export class InviteSyncProcessState {
-    invite: Invite;
-    isNewInvite: boolean;
-    roomResponse: InvitedRoom | undefined;
-    membership: "join" | "leave" | "invite";
-    changes?: InviteWriteSyncChanges;
-
-    constructor(invite: Invite, isNewInvite: boolean, roomResponse: InvitedRoom | undefined, membership: "join" | "leave" | "invite") {
-        this.invite = invite;
-        this.isNewInvite = isNewInvite;
-        this.membership = membership;
-        this.roomResponse = roomResponse;
-    }
-
-    get id(): string {
-        return this.invite.id;
-    }
-
-    get shouldAdd(): boolean {
-        return this.isNewInvite;
-    }
-
-    get shouldRemove(): boolean {
-        return this.membership !== "invite";
-    }
-}
-

--- a/src/matrix/room/BaseRoom.ts
+++ b/src/matrix/room/BaseRoom.ts
@@ -36,7 +36,7 @@ import {Membership, RoomEventType} from "../net/types/roomEvents";
 import type {Storage} from "../storage/idb/Storage";
 import type {HomeServerApi} from "../net/HomeServerApi";
 import type {MediaRepository} from "../net/MediaRepository";
-import type {Room} from "./Room";
+import type {InstantMessageRoom} from "./InstantMessageRoom";
 import type {RoomEncryption, SummaryData} from "../e2ee/RoomEncryption";
 import type {User} from "../User";
 import type {RoomMember} from "./members/RoomMember";
@@ -58,7 +58,7 @@ export type Options = {
     mediaRepository: MediaRepository;
     emitCollectionChange: (room: BaseRoom, params: any) => boolean | undefined;
     user: User;
-    createRoomEncryption: (room: Room, encryptionParams: EncryptionParams) => RoomEncryption | null;
+    createRoomEncryption: (room: InstantMessageRoom, encryptionParams: EncryptionParams) => RoomEncryption | null;
     getSyncToken: () => string | undefined;
     platform: Platform;
 }

--- a/src/matrix/room/InstantMessageRoomManager.ts
+++ b/src/matrix/room/InstantMessageRoomManager.ts
@@ -1,0 +1,592 @@
+import {
+    InstantMessageRoom,
+    InstantMessageRoomPreparation,
+    InstantMessageRoomWriteChanges,
+} from './InstantMessageRoom';
+import { IRoomManager } from './RoomManager';
+import { Invite } from './Invite';
+import { ArchivedRoom } from './ArchivedRoom';
+import { IncomingRoomKey } from '../e2ee/megolm/decryption/RoomKey';
+import { Transaction } from '../storage/idb/Transaction';
+import { ILogItem } from '../../logging/types';
+import { ObservableMap } from '../../observable';
+import { InvitedRoom, JoinedRoom, LeftRoom, Rooms } from '../net/types/sync';
+import { timelineIsEmpty } from '../Sync';
+import { RoomStatus } from '../../lib';
+import { StoreNames } from '../storage/common';
+import { PendingEntry } from '../storage/idb/stores/PendingEventStore';
+import { PendingEventData } from './sending/PendingEvent';
+import { Session } from '../Session';
+import { Membership } from '../net/types/roomEvents';
+import { MemberData } from './members/RoomMember';
+
+export class InstantMessageRoomManager implements IRoomManager<InstantMessageRoom, Invite, ArchivedRoom> {
+    private _session?: Session;
+    private _rooms: ObservableMap<string, InstantMessageRoom> = new ObservableMap();
+    private _roomSyncStates: RoomSyncProcessState[] = [];
+    private _invites: ObservableMap<string, Invite> = new ObservableMap();
+    private _inviteSyncStates: InviteSyncProcessState[] = [];
+    private _archivedRooms: ObservableMap<string, ArchivedRoom> = new ObservableMap();
+    private _archivedRoomSyncStates: ArchivedRoomSyncProcessState[] = [];
+
+    constructor() {
+        // Bind to this so that it behaves correctly when passed to other objects.
+        this._forgetArchivedRoom = this._forgetArchivedRoom.bind(this);
+    }
+
+    init(session: Session) {
+        this._session = session;
+    }
+
+    get storesForLoad(): string[] {
+        return [
+            StoreNames.roomSummary,
+            StoreNames.invites,
+            StoreNames.roomMembers,
+            StoreNames.timelineEvents,
+            StoreNames.timelineFragments,
+            StoreNames.pendingEvents,
+        ]
+    }
+
+    async createLoadPromises(txn: Transaction, log: ILogItem): Promise<Promise<void>[]> {
+        // const pendingEventsByRoomId = await this._getPendingEventsByRoom(txn);
+        // const invites = await txn.invites.getAll();
+        // const roomSummaries = await txn.roomSummary.getAll();
+        const [pendingEventsByRoomId, invites, roomSummaries] = await Promise.all([this._getPendingEventsByRoom(txn), txn.invites.getAll(), txn.roomSummary.getAll()]);
+
+        const inviteLoadPromises = invites.map(async inviteData => {
+            const invite = this._createInvite(inviteData.roomId);
+            if (log) { log.wrap("invite", log => invite.load(inviteData, log)); } else { invite.load(inviteData, log) };
+            this._invites.add(invite.id, invite);
+        });
+
+        const roomLoadPromises = roomSummaries.map(async summary => {
+            const room = this._createJoinedRoom(summary.roomId!, pendingEventsByRoomId.get(summary.roomId!));
+            await log.wrap("room", log => room.load(summary, txn, log));
+            this._rooms.add(room.id, room);
+        });
+
+        return [...inviteLoadPromises, ...roomLoadPromises]
+    }
+
+    async initSync(roomsResponse: Rooms | undefined, isInitialSync: boolean, log: ILogItem): Promise<void> {
+        this._resetSyncStates();
+        this._parseInvites(roomsResponse);
+        await this._parseRoomsResponse(roomsResponse, isInitialSync, log);
+    }
+
+    get storesForPrepareSync(): string[] {
+        return [
+            StoreNames.inboundGroupSessions,
+            // to read fragments when loading sync writer when rejoining archived room
+            StoreNames.timelineFragments,
+            // to read fragments when loading sync writer when rejoining archived room
+            // to read events that can now be decrypted
+            StoreNames.timelineEvents,
+        ]
+    }
+
+    async prepareSync(
+        roomsResponse: Rooms | undefined,
+        newKeysByRoom: Map<string, IncomingRoomKey[]> | undefined,
+        prepareTxn: Transaction,
+        log: ILogItem
+    ) {
+        // add any rooms with new keys but no sync response to the list of rooms to be synced
+        if (newKeysByRoom) {
+            const { hasOwnProperty } = Object.prototype;
+            for (const roomId of newKeysByRoom.keys()) {
+                const isRoomInResponse =
+                    roomsResponse?.join && hasOwnProperty.call(roomsResponse.join, roomId);
+                if (!isRoomInResponse) {
+                    let room = this._rooms?.get(roomId);
+                    if (room) {
+                        this._roomSyncStates.push(
+                            new RoomSyncProcessState(room, false, {}, room.membership)
+                        );
+                    }
+                }
+            }
+        }
+
+        await Promise.all(this._roomSyncStates.map(async jrss => {
+            const newKeys = newKeysByRoom?.get(jrss.room.id) ?? [];
+            jrss.preparation = await log.wrap('room', async log => {
+                // if previously joined and we still have the timeline for it,
+                // this loads the syncWriter at the correct position to continue writing the timeline
+                if (jrss.isNewRoom) {
+                    await jrss.room.load(undefined, prepareTxn, log);
+                }
+                return jrss.room.prepareSync(
+                    jrss.roomResponse, jrss.membership, newKeys, prepareTxn, log);
+            }, log.level.Detail);
+        }));
+    }
+
+    async afterPrepareSync(log: ILogItem): Promise<void> {
+        await Promise.all(this._roomSyncStates.map(jrss => {
+            return jrss.room.afterPrepareSync(jrss.preparation, log);
+        }));
+    }
+
+    get storesForWriteSync(): string[] {
+        return [
+            StoreNames.roomSummary,
+            StoreNames.archivedRoomSummary,
+            StoreNames.invites,
+            StoreNames.roomState,
+            StoreNames.roomMembers,
+            StoreNames.timelineEvents,
+            StoreNames.timelineRelations,
+            StoreNames.timelineFragments,
+            StoreNames.pendingEvents,
+        ]
+    }
+
+    async writeSync(syncTxn: Transaction, isInitialSync: boolean, log: ILogItem): Promise<void> {
+        await Promise.all(this._inviteSyncStates.map(async irss => {
+            irss.changes = await log.wrap("invite", log => irss.invite.writeSync(
+                irss.membership, irss.roomResponse, syncTxn, log));
+        }));
+        await Promise.all(this._roomSyncStates.map(async jrss => {
+            jrss.changes = await log.wrap("room", log => jrss.room.writeSync(
+                jrss.preparation!, jrss.roomResponse, isInitialSync, syncTxn, log));
+        }));
+        // important to do this after this._joinRoomSyncStates,
+        // as we're referring to the roomState to get the summaryChanges
+        await Promise.all(this._archivedRoomSyncStates.map(async lrss => {
+            const summaryChanges = lrss.roomState?.summaryChanges;
+            lrss.changes = await log.wrap("archivedRoom", log => lrss.archivedRoom.writeSync(
+                summaryChanges, lrss.roomResponse, lrss.membership, syncTxn, log));
+        }));
+    }
+
+    async afterSync(log: ILogItem): Promise<void> {
+        for(let ars of this._archivedRoomSyncStates) {
+            log.wrap("archivedRoom", log => {
+                ars.archivedRoom.afterSync(ars.changes, log);
+                ars.archivedRoom.release();
+            }, log.level.Detail);
+        }
+        for(let rs of this._roomSyncStates) {
+            if (!rs.changes) throw new Error("missing changes")
+            log.wrap("room", log => rs.room.afterSync(rs.changes!, log), log.level.Detail);
+        }
+        for(let is of this._inviteSyncStates) {
+            log.wrap("invite", log => is.invite.afterSync(is.changes, log), log.level.Detail);
+        }
+
+        this._applyRoomCollectionChangesAfterSync(log);
+    }
+
+    async afterSyncCompleted(log: ILogItem): Promise<void> {
+        const roomsPromises = this._roomSyncStates.map(async rss => {
+            try {
+                if (!rss.changes) throw new Error("missing changes")
+                await rss.room.afterSyncCompleted(rss.changes, log);
+            } catch (err) {} // error is logged, but don't fail roomsPromises
+        });
+        await Promise.all(roomsPromises)
+    }
+
+    async dispose() {
+        for (const [_, room] of this._rooms) {
+            room.dispose();
+        }
+    }
+
+    get joinRooms(): ObservableMap<string, InstantMessageRoom> {
+        return this._rooms;
+    }
+    get inviteRooms(): ObservableMap<string, Invite> {
+        return this._invites;
+    }
+    get leaveRooms(): ObservableMap<string, ArchivedRoom> {
+        return this._archivedRooms;
+    }
+
+    private get session(): Session {
+        if (this._session === undefined) {
+            throw new Error("cannot be used until init(session) has been called");
+        }
+        return this._session;
+    }
+
+    private _resetSyncStates() {
+        this._roomSyncStates = [];
+        this._inviteSyncStates = [];
+        this._archivedRoomSyncStates = [];
+    }
+
+    private _parseInvites(roomsResponse?: Rooms) {
+        if (roomsResponse?.invite) {
+            for (const [roomId, _roomResponse] of Object.entries(roomsResponse.invite)) {
+                const roomResponse = _roomResponse as InvitedRoom;
+                let invite = this._invites.get(roomId);
+                let isNewInvite = false;
+                if (!invite) {
+                    invite = this._createInvite(roomId);
+                    isNewInvite = true;
+                }
+                this._inviteSyncStates.push(new InviteSyncProcessState(invite, isNewInvite, roomResponse, "invite"));
+            }
+        }
+    }
+
+    private async _parseRoomsResponse(
+        roomsResponse: Rooms | undefined,
+        isInitialSync: boolean,
+        log: ILogItem
+    ): Promise<void> {
+        if (roomsResponse) {
+            const allMemberships: ('join' | 'leave')[] = ['join', 'leave'];
+            for (const membership of allMemberships) {
+                const membershipSection = roomsResponse[membership];
+                if (membershipSection) {
+                    for (const [roomId, _roomResponse] of Object.entries(membershipSection)) {
+                        const roomResponse: JoinedRoom | LeftRoom = _roomResponse;
+                        // ignore rooms with empty timelines during initial sync,
+                        // see https://github.com/vector-im/hydrogen-web/issues/15
+                        if (isInitialSync && timelineIsEmpty(roomResponse)) {
+                            continue;
+                        }
+                        const invite = this._invites.get(roomId);
+                        // if there is an existing invite, add a process state for it
+                        // so its writeSync and afterSync will run and remove the invite
+                        if (invite) {
+                            this._inviteSyncStates.push(new InviteSyncProcessState(invite, false, undefined, membership));
+                        }
+                        const roomState = this._createRoomSyncState( roomId, roomResponse, membership, isInitialSync);
+                        if (roomState) {
+                            this._roomSyncStates.push(roomState);
+                        }
+                        const ars = await this._createArchivedRoomSyncState(
+                            roomId, roomState, roomResponse, membership, isInitialSync, log);
+                        if (ars) {
+                            this._archivedRoomSyncStates.push(ars);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private _createRoomSyncState(roomId: string, roomResponse: JoinedRoom | LeftRoom, membership: "join" | "leave", isInitialSync: boolean): RoomSyncProcessState | undefined {
+        let isNewRoom = false;
+        let room = this._rooms.get(roomId);
+        // create room only either on new join,
+        // or for an archived room during initial sync,
+        // where we create the summaryChanges with a joined
+        // room to then adopt by the archived room.
+        // This way the limited timeline, members, ...
+        // we receive also gets written.
+        // In any case, don't create a room for a rejected invite
+        if (!room && (membership === "join" || (isInitialSync && membership === "leave"))) {
+            room = this._createJoinedRoom(roomId);
+            isNewRoom = true;
+        }
+        if (room) {
+            return new RoomSyncProcessState(
+                room, isNewRoom, roomResponse, membership);
+        }
+    }
+
+    private async _createArchivedRoomSyncState(
+        roomId: string,
+        roomState: RoomSyncProcessState | undefined,
+        roomResponse: JoinedRoom | LeftRoom,
+        membership: 'join' | 'leave',
+        isInitialSync: boolean,
+        log: ILogItem
+      ): Promise<ArchivedRoomSyncProcessState | undefined> {
+        let archivedRoom: ArchivedRoom | undefined;
+        if (roomState?.shouldAdd && !isInitialSync) {
+            // when adding a joined room during incremental sync,
+            // always create the archived room to write the removal
+            // of the archived summary
+            archivedRoom = this._createOrGetArchivedRoomForSync(roomId);
+        } else if (membership === "leave") {
+            if (roomState) {
+                // we still have a roomState, so we just left it
+                // in this case, create a new archivedRoom
+                archivedRoom = this._createOrGetArchivedRoomForSync(roomId);
+            } else {
+                // this is an update of an already left room, restore
+                // it from storage first, so we can increment it.
+                // this happens for example when our membership changes
+                // after leaving (e.g. being (un)banned, possibly after being kicked), etc
+                archivedRoom = await this.loadArchivedRoom(roomId, log);
+            }
+        }
+        if (archivedRoom) {
+            return new ArchivedRoomSyncProcessState(
+                archivedRoom, roomState, roomResponse, membership);
+        }
+    }
+
+    /**
+     * Creates an empty (summary isn't loaded) the archived room if it isn't
+     * loaded already, assuming sync will either remove it (when rejoining) or
+     * write a full summary adopting it from the joined room when leaving.
+    */
+    private _createOrGetArchivedRoomForSync(roomId: string): ArchivedRoom {
+        let archivedRoom = this._archivedRooms.get(roomId);
+        if (archivedRoom) {
+            archivedRoom.retain();
+        } else {
+            archivedRoom = this._createArchivedRoom(roomId);
+        }
+        return archivedRoom;
+    }
+
+    private _applyRoomCollectionChangesAfterSync(log: ILogItem) {
+        // update the collections after sync
+        for (const rs of this._roomSyncStates) {
+            if (rs.shouldAdd) {
+                this._rooms?.add(rs.id, rs.room);
+                this.session._tryReplaceRoomBeingCreated(rs.id, log);
+            } else if (rs.shouldRemove) {
+                this._rooms?.remove(rs.id);
+            }
+        }
+        for (const is of this._inviteSyncStates) {
+            if (is.shouldAdd) {
+                this._invites.add(is.id, is.invite);
+            } else if (is.shouldRemove) {
+                this._invites.remove(is.id);
+            }
+        }
+        // now all the collections are updated, update the room status
+        // so any listeners to the status will find the collections
+        // completely up to date
+        if (this.session._observedRoomStatus.size !== 0) {
+            for (const ars of this._archivedRoomSyncStates) {
+                if (ars.shouldAdd) {
+                    this.session._observedRoomStatus.get(ars.id)?.set(RoomStatus.Archived);
+                }
+            }
+            for (const rs of this._roomSyncStates) {
+                if (rs.shouldAdd) {
+                    this.session._observedRoomStatus.get(rs.id)?.set(RoomStatus.Joined);
+                }
+            }
+            for (const is of this._inviteSyncStates) {
+                const statusObservable = this.session._observedRoomStatus.get(is.id);
+                if (statusObservable) {
+                    const withInvited = statusObservable.get() | RoomStatus.Invited;
+                    if (is.shouldAdd) {
+                        statusObservable.set(withInvited);
+                    } else if (is.shouldRemove) {
+                        const withoutInvited = withInvited ^ RoomStatus.Invited;
+                        statusObservable.set(withoutInvited);
+                    }
+                }
+            }
+        }
+    }
+
+    private async _getPendingEventsByRoom(txn: Transaction): Promise<Map<string, [PendingEntry]>> {
+        const pendingEvents = await txn.pendingEvents.getAll();
+        return pendingEvents.reduce((groups, pe) => {
+            const group = groups.get(pe.roomId);
+            if (group) {
+                group.push(pe);
+            } else {
+                groups.set(pe.roomId, [pe]);
+            }
+            return groups;
+        }, new Map<string, [PendingEntry]>());
+    }
+
+    private _createInvite(roomId: string): Invite {
+        return new Invite({
+            roomId,
+            hsApi: this.session.hsApi,
+            emitCollectionUpdate: (invite: Invite, params: any) => this._invites.update(invite.id, params),
+            mediaRepository: this.session.mediaRepository,
+            user: this.session.user,
+            platform: this.session.platform,
+        });
+    }
+
+    private _createJoinedRoom(roomId: string, pendingEvents?: PendingEventData[]): InstantMessageRoom {
+        return new InstantMessageRoom({
+            roomId,
+            getSyncToken: this.session._getSyncToken,
+            storage: this.session.storage,
+            emitCollectionChange: (room, params) => this._rooms?.update(room.id, params),
+            hsApi: this.session.hsApi,
+            mediaRepository: this.session.mediaRepository,
+            pendingEvents,
+            user: this.session.user,
+            createRoomEncryption: this.session._createRoomEncryption,
+            platform: this.session.platform
+        });
+    }
+
+    loadArchivedRoom(roomId: string, log?: ILogItem): ArchivedRoom | undefined {
+        return this.session.platform.logger.wrapOrRun(log, "loadArchivedRoom", async log => {
+            log.set("id", roomId);
+            const activeArchivedRoom = this._archivedRooms.get(roomId);
+            if (activeArchivedRoom) {
+                activeArchivedRoom.retain();
+                return activeArchivedRoom;
+            }
+            const txn = await this.session.storage.readTxn([
+                this.session.storage.storeNames.archivedRoomSummary,
+                this.session.storage.storeNames.roomMembers,
+            ]);
+            const summary = await txn.archivedRoomSummary.get(roomId);
+            if (summary) {
+                const room = this._createArchivedRoom(roomId);
+                await room.load(summary, txn, log);
+                return room;
+            }
+        });
+    }
+
+    private _forgetArchivedRoom(roomId: string) {
+        const statusObservable = this.session._observedRoomStatus.get(roomId);
+        if (statusObservable) {
+            statusObservable.set((statusObservable.get() | RoomStatus.Archived) ^ RoomStatus.Archived);
+        }
+    }
+
+    /** @internal */
+    private _createArchivedRoom(roomId: string): ArchivedRoom {
+        const room = new ArchivedRoom({
+            roomId,
+            getSyncToken: this.session._getSyncToken,
+            storage: this.session.storage,
+            emitCollectionChange: () => {},
+            releaseCallback: () => this._archivedRooms.remove(roomId),
+            forgetCallback: this._forgetArchivedRoom,
+            hsApi: this.session.hsApi,
+            mediaRepository: this.session.mediaRepository,
+            user: this.session.user,
+            createRoomEncryption: this.session._createRoomEncryption,
+            platform: this.session.platform
+        });
+        this._archivedRooms.set(roomId, room);
+        return room;
+    }
+}
+
+class RoomSyncProcessState {
+    /**
+     * @param {Object} roomResponse - a matrix Joined Room type or matrix Left Room type
+     */
+    room: InstantMessageRoom;
+    isNewRoom: boolean;
+    roomResponse: JoinedRoom | LeftRoom;
+    membership?: Membership;
+    preparation?: InstantMessageRoomPreparation;
+    changes?: InstantMessageRoomWriteChanges;
+
+    constructor(room: InstantMessageRoom, isNewRoom: boolean, roomResponse: JoinedRoom | LeftRoom, membership?: Membership) {
+        this.room = room;
+        this.isNewRoom = isNewRoom;
+        this.roomResponse = roomResponse;
+        this.membership = membership;
+    }
+
+    get id() {
+        return this.room.id;
+    }
+
+    get shouldAdd() {
+        return this.isNewRoom && this.membership === "join";
+    }
+
+    get shouldRemove() {
+        return !this.isNewRoom && this.membership !== "join";
+    }
+
+    get summaryChanges() {
+        return this.changes?.summaryChanges;
+    }
+}
+
+
+class ArchivedRoomSyncProcessState {
+    archivedRoom: ArchivedRoom;
+    roomState: RoomSyncProcessState | undefined;
+    roomResponse: JoinedRoom | LeftRoom;
+    membership: "join" | "leave";
+    isInitialSync?: boolean;
+    changes?: {};
+
+    constructor(archivedRoom: ArchivedRoom, roomState: RoomSyncProcessState | undefined, roomResponse: JoinedRoom | LeftRoom, membership: "join" | "leave", isInitialSync?: boolean) {
+        this.archivedRoom = archivedRoom;
+        this.roomState = roomState;
+        this.roomResponse = roomResponse;
+        this.membership = membership;
+        this.isInitialSync = isInitialSync;
+    }
+
+    get id(): string {
+        return this.archivedRoom.id;
+    }
+
+    get shouldAdd(): boolean | undefined {
+        return (this.roomState || this.isInitialSync) && this.membership === "leave";
+    }
+
+    get shouldRemove(): boolean {
+        return this.membership === "join";
+    }
+}
+
+// TODO: move this to a more appropriate file
+// https://spec.matrix.org/v1.4/client-server-api/#mroomjoin_rules
+type JoinRule = "public" | "knock" | "invite" | "private" | "restricted"
+
+// TODO: move to Invite.js when that gets converted to typescript.
+// It's the return value of Invite._createData().
+type InviteData = {
+    roomId: string,
+    isEncrypted: boolean,
+    isDirectMessage: boolean,
+    name?: string,
+    avatarUrl?: string,
+    avatarColorId: string | null,
+    canonicalAlias: string | null,
+    timestamp: number,
+    joinRule: JoinRule | null,
+    inviter?: MemberData,
+}
+
+// TODO: move to Invite.js when that gets converted to typescript.
+// It's the return value of Invite.writeSync().
+type InviteWriteSyncChanges =
+  | { removed: true; membership: "join" | "leave" | "invite" }
+  | { inviteData: InviteData; inviter?: MemberData };
+
+class InviteSyncProcessState {
+    invite: Invite;
+    isNewInvite: boolean;
+    roomResponse: InvitedRoom | undefined;
+    membership: "join" | "leave" | "invite";
+    changes?: InviteWriteSyncChanges;
+
+    constructor(invite: Invite, isNewInvite: boolean, roomResponse: InvitedRoom | undefined, membership: "join" | "leave" | "invite") {
+        this.invite = invite;
+        this.isNewInvite = isNewInvite;
+        this.membership = membership;
+        this.roomResponse = roomResponse;
+    }
+
+    get id(): string {
+        return this.invite.id;
+    }
+
+    get shouldAdd(): boolean {
+        return this.isNewInvite;
+    }
+
+    get shouldRemove(): boolean {
+        return this.membership !== "invite";
+    }
+}
+

--- a/src/matrix/room/RoomManager.ts
+++ b/src/matrix/room/RoomManager.ts
@@ -4,6 +4,7 @@ import { IncomingRoomKey } from '../e2ee/megolm/decryption/RoomKey';
 import { Rooms } from '../net/types/sync';
 import { Session } from '../Session';
 import { Transaction } from '../storage/idb/Transaction';
+import { InstantMessageRoomManager } from './InstantMessageRoomManager';
 
 // An IRoomManager is responsible for managing the lifecycle of a particular
 // room type (https://spec.matrix.org/v1.4/client-server-api/#types).
@@ -100,3 +101,6 @@ export interface IRoomManager<J, I, L> {
     get leaveRooms(): ObservableMap<string, L>;
 }
 
+export function getDefaultRoomManagers(): Map<string, IRoomManager<any, any, any>> {
+    return new Map([['imRooms', new InstantMessageRoomManager()]])
+}

--- a/src/matrix/room/RoomManager.ts
+++ b/src/matrix/room/RoomManager.ts
@@ -1,0 +1,102 @@
+import { ILogItem } from '../../logging/types';
+import { ObservableMap } from '../../observable';
+import { IncomingRoomKey } from '../e2ee/megolm/decryption/RoomKey';
+import { Rooms } from '../net/types/sync';
+import { Session } from '../Session';
+import { Transaction } from '../storage/idb/Transaction';
+
+// An IRoomManager is responsible for managing the lifecycle of a particular
+// room type (https://spec.matrix.org/v1.4/client-server-api/#types).
+//
+// These responsibilities include managing the in-memory and on-disk representations
+// of a room type, and updating these representations upon a sync response, for each of
+// "invite", "join", and "leave" ("knock" is currently not supported).
+export interface IRoomManager<J, I, L> {
+    /**
+     * init is called once when the application is first loaded,
+     * giving it a chance to store a reference to the Session if necessary.
+     */
+    init(session: Session): void;
+
+    /**
+     * storesForLoad returns a list of the idb store names required in the
+     * Transaction passed to createLoadPromises.
+     */
+    get storesForLoad(): string[];
+    /**
+     * createLoadPromises is called once when the application is first loaded.
+     * This is typically where you would create promises to load existing room
+     * data saved in idb into memory.
+     *
+     * The api asks for a list of Promise<void> back so that async operations
+     * can be run concurrently with those of other IRoomManagers.
+     */
+    createLoadPromises(txn: Transaction, log: ILogItem): Promise<Promise<void>[]>;
+
+    /**
+     * initSync is called when a new sync response is received. It is where any of the room manager's
+     * state from the previous sync can be reset and/or initialized for the upcoming sync cycle.
+     */
+    initSync(roomsResponse: Rooms | undefined, isInitialSync: boolean, log: ILogItem): Promise<void>;
+    /**
+     * storesForPrepareSync returns a list of the idb store names required in the
+     * Transaction passed to prepareSync.
+     */
+    get storesForPrepareSync(): string[];
+    /**
+     * prepareSync is the idb read phase of the sync cycle
+     * @param roomsResponse the rooms section of the sync response
+     * @param newKeysByRoom new keys returned by this sync response, mapped to room id
+     * @param prepareTxn read transaction with the stores returned by storesForPrepareSync
+     */
+    prepareSync(
+        roomsResponse: Rooms | undefined,
+        newKeysByRoom: Map<string, IncomingRoomKey[]> | undefined,
+        prepareTxn: Transaction,
+        log: ILogItem
+    ): Promise<void>;
+    /**
+     * called after prepareSync
+     */
+    afterPrepareSync(log: ILogItem): Promise<void>; // todo(isaiah): can we just get rid of this and push this processing to prepareSync?
+    /**
+     * storesForWriteSync returns a list of the idb store names required in the
+     * Transaction passed to writeSync.
+     */
+    get storesForWriteSync(): string[];
+    /**
+     * prepareSync is the idb write phase of the sync cycle
+     * @param syncTxn write transaction with the stores returned by storesForWriteSync
+     */
+    writeSync(syncTxn: Transaction, isInitialSync: boolean, log: ILogItem): Promise<void>;
+    /**
+     * afterSync is the in-memory update phase of the sync cycle.
+     * This is where any in-memory representations of objects that were
+     * changed by sync should be updated.
+     */
+    afterSync(log: ILogItem): Promise<void>;
+    /**
+     * called after afterSync
+     */
+    afterSyncCompleted(log: ILogItem): Promise<void>; // todo(isaiah): can we just get rid of this and push this processing to prepareSync?
+
+    /**
+     * dispose is where to take care of any references that need to be explicitly
+     * disposed to avoid memory leaks, or any other cleanup tasks.
+     */
+    dispose(): Promise<void>;
+
+    /**
+     * The in-memory representation of "join" rooms
+     */
+    get joinRooms(): ObservableMap<string, J>;
+    /**
+     * The in-memory representation of "invite" rooms
+     */
+    get inviteRooms(): ObservableMap<string, I>;
+    /**
+     * The in-memory representation of "leave" rooms
+     */
+    get leaveRooms(): ObservableMap<string, L>;
+}
+

--- a/src/matrix/storage/idb/Storage.ts
+++ b/src/matrix/storage/idb/Storage.ts
@@ -42,15 +42,7 @@ export class Storage {
         this.logger = logger;
     }
 
-    _validateStoreNames(storeNames: StoreNames[]): void {
-        const idx = storeNames.findIndex(name => !STORE_NAMES.includes(name));
-        if (idx !== -1) {
-            throw new StorageError(`Tried top, a transaction unknown store ${storeNames[idx]}`);
-        }
-    }
-
-    async readTxn(storeNames: StoreNames[]): Promise<Transaction> {
-        this._validateStoreNames(storeNames);
+    async readTxn(storeNames: (StoreNames | string)[]): Promise<Transaction> {
         try {
             const txn = this._db.transaction(storeNames, "readonly");
             // https://bugs.webkit.org/show_bug.cgi?id=222746 workaround,
@@ -64,8 +56,7 @@ export class Storage {
         }
     }
 
-    async readWriteTxn(storeNames: StoreNames[]): Promise<Transaction> {
-        this._validateStoreNames(storeNames);
+    async readWriteTxn(storeNames: (StoreNames | string)[]): Promise<Transaction> {
         try {
             const txn = this._db.transaction(storeNames, "readwrite");
             // https://bugs.webkit.org/show_bug.cgi?id=222746 workaround,

--- a/src/matrix/storage/idb/Transaction.ts
+++ b/src/matrix/storage/idb/Transaction.ts
@@ -51,12 +51,12 @@ class WriteErrorInfo {
 
 export class Transaction {
     private _txn: IDBTransaction;
-    private _allowedStoreNames: StoreNames[];
+    private _allowedStoreNames: (StoreNames | string)[];
     private _stores: { [storeName in StoreNames]?: any };
     private _storage: Storage;
     private _writeErrors: WriteErrorInfo[];
 
-    constructor(txn: IDBTransaction, allowedStoreNames: StoreNames[], storage: Storage) {
+    constructor(txn: IDBTransaction, allowedStoreNames: (StoreNames | string)[], storage: Storage) {
         this._txn = txn;
         this._allowedStoreNames = allowedStoreNames;
         this._stores = {};


### PR DESCRIPTION
# `IRoomManager`
The crux of this change is in `src/matrix/room/RoomManager.ts`, which has `IRoomManager`:

```typescript
// An IRoomManager is responsible for managing the lifecycle of a particular
// room type (https://spec.matrix.org/v1.4/client-server-api/#types).
//
// These responsibilities include managing the in-memory and on-disk representations
// of a room type, and updating these representations upon a sync response, for each of
// "invite", "join", and "leave" ("knock" is currently not supported).
export interface IRoomManager<J, I, L> {
    // see file itself for details
}
```

When a `Client` is created, it's passed in a `Map<string, IRoomManager>`, which is a map of identifiers to `IRoomManager`. Currently, we only have one class implementing `IRoomManager`, named `InstantMessageRoomManager`, and it's by default passed in by calling `getDefaultRoomManagers`, with the identifier `'imRooms'`:

```typescript
export function getDefaultRoomManagers(): Map<string, IRoomManager<any, any, any>> {
    return new Map([['imRooms', new InstantMessageRoomManager()]])
}
```

In the future, when we implement spaces, this will look like
```typescript
export function getDefaultRoomManagers(): Map<string, IRoomManager<any, any, any>> {
    return new Map([
        ['imRooms', new InstantMessageRoomManager()],
        ['spaceRooms', new SpaceRoomManager()],
    ])
}
```

Once this API gets polished off, sdk users will have the option to pass in any sort of `IRoomManager` they desire, to add support for new room types.

## `IRoomManager`s in `Session`

This map of `IRoomManager`, ultimately gets passed down to `Session`. Now instead of a `Session` having fields like

```typescript
class Session {
    private _rooms?: ObservableMap<string, Room>;
    private _invites: ObservableMap<string, Invite>;
    private _activeArchivedRooms: Map<string, ArchivedRoom>;
    private _spaces: ObservableMap<string, Space>; // in the future
}
```

It just has one field that handles all of those
```typescript
class Session {
    private _roomManagers: Map<string, IRoomManager<any, any, any>>;
}
```

What was once `Session._rooms` becomes `Session._roomManagers.get('imRooms').joinRooms`
`Session._invites` --> `Session._roomManagers.get('imRooms').inviteRooms`
`Session._activeArchivedRooms` --> `Session._roomManagers.get('imRooms').leaveRooms`

## `IRoomManager` in `Sync`

An `IRoomManager` doesn't merely hold a type of room in memory -- it also provides an API that `Sync` knows how to use in order to update that type of room on disk and on memory as new /sync responses come in. Now instead of `Sync` being responsible for all of the inner details of an instant message room's state throughout the sync process, it just knows of an `IRoomManager` on which it can call `prepareSync`, `afterPrepareSync`, `writeSync`, etc. 

All of the internal state that `Sync` once dealt with in the form of lists of `RoomSyncProcessState` (among others) is now abstracted away from it. `RoomSyncProcessState` now lives in `InstantMessageRoomManager`, which as an `IRoomManager` is responsible for managing the state of the sync cycle for it's particular room type.

## Going forward

Ultimately the idea here is to make it easy for new `IRoomManager`s to be passed in to the `Client` to support new room types. To realize that ideal, I see at least two things that will need to be added:

1. Support for Bruno's idea of having a `createSchema(db, txn, oldVersion, version, log)` in the interface, so that idb schema configuration (and upgrades) can be instantiated
2. A function that we pass to each `IRoomManager` which decides which rooms in the sync response that room manager deals with. The idea being -- currently, if an `InstantMessageRoomManager` sees a space room, it will manage it anyhow. When I add support for `SpaceRoomManager`, I will need some way to tell `InstantRoomManager` to ignore any `m.room.create` events that have `"content": {"type": "m.space", ...}`, and some way to tell `SpaceRoomManager` that those _are_ its responsibility. Assuming we wish to make this an API that anybody can update with new room types, we will want this to be something they can modify in the future, so as to tell existing `IRoomManager`s new responses to ignore.